### PR TITLE
Expose Lists components publicly

### DIFF
--- a/Sources/DesignSystem/Views/Lists/VGRCheckRow.swift
+++ b/Sources/DesignSystem/Views/Lists/VGRCheckRow.swift
@@ -22,7 +22,7 @@ import SwiftUI
 ///     VGRCheckRow(title: item.title, isSelected: selection.contains(item))
 /// }
 /// ```
-struct VGRCheckRow<Accessory: View>: View {
+public struct VGRCheckRow<Accessory: View>: View {
 
     /// The primary text shown on the row.
     var title: String
@@ -65,7 +65,7 @@ struct VGRCheckRow<Accessory: View>: View {
         self.accessory = EmptyView()
     }
 
-    var body: some View {
+    public var body: some View {
         VGRListRow(title: title,
                    subtitle: subtitle,
                    icon: {

--- a/Sources/DesignSystem/Views/Lists/VGRContainer.swift
+++ b/Sources/DesignSystem/Views/Lists/VGRContainer.swift
@@ -21,7 +21,7 @@ import SwiftUI
 ///     }
 /// }
 /// ```
-struct VGRContainer<Content: View>: View {
+public struct VGRContainer<Content: View>: View {
 
     private let content: Content
 
@@ -32,7 +32,7 @@ struct VGRContainer<Content: View>: View {
         self.content = content()
     }
 
-    var body: some View {
+    public var body: some View {
         ScrollView {
             VStack(spacing: .Margins.xtraLarge) {
                 content

--- a/Sources/DesignSystem/Views/Lists/VGRList.swift
+++ b/Sources/DesignSystem/Views/Lists/VGRList.swift
@@ -27,7 +27,7 @@ import SwiftUI
 ///     }
 /// }
 /// ```
-struct VGRList<Content: View>: View {
+public struct VGRList<Content: View>: View {
 
     private let content: Content
     private var showWarning: Bool = false
@@ -43,7 +43,7 @@ struct VGRList<Content: View>: View {
         self.content = content()
     }
 
-    var body: some View {
+    public var body: some View {
         VStack(spacing: 0) {
             Group(subviews: content) { subviews in
                 ForEach(subviews.indices, id: \.self) { index in

--- a/Sources/DesignSystem/Views/Lists/VGRListRow.swift
+++ b/Sources/DesignSystem/Views/Lists/VGRListRow.swift
@@ -27,7 +27,7 @@ import SwiftUI
 ///            icon: { Image(systemName: "bolt") },
 ///            accessory: { Text("Detail") })
 /// ```
-struct VGRListRow<Icon: View, Accessory: View>: View {
+public struct VGRListRow<Icon: View, Accessory: View>: View {
 
     /// The primary text shown on the row.
     let title: String
@@ -81,7 +81,7 @@ struct VGRListRow<Icon: View, Accessory: View>: View {
         return subtitle != nil ? .Margins.small : .Margins.medium
     }
 
-    var body: some View {
+    public var body: some View {
         HStack(spacing: .Margins.xtraSmall) {
 
             if let icon {

--- a/Sources/DesignSystem/Views/Lists/VGRNavRow.swift
+++ b/Sources/DesignSystem/Views/Lists/VGRNavRow.swift
@@ -31,7 +31,7 @@ import SwiftUI
 ///     DestinationView()
 /// }
 /// ```
-struct VGRNavRow<Icon: View, Accessory: View, Destination: View>: View {
+public struct VGRNavRow<Icon: View, Accessory: View, Destination: View>: View {
 
     @ScaledMetric private var chevronSize: CGFloat = 25
 
@@ -115,7 +115,7 @@ struct VGRNavRow<Icon: View, Accessory: View, Destination: View>: View {
         self.destination = destination()
     }
 
-    var body: some View {
+    public var body: some View {
         NavigationLink {
             destination
         } label: {

--- a/Sources/DesignSystem/Views/Lists/VGRSection.swift
+++ b/Sources/DesignSystem/Views/Lists/VGRSection.swift
@@ -31,7 +31,7 @@ import SwiftUI
 ///     VGRList { VGRListRow(title: "…") }
 /// }
 /// ```
-struct VGRSection<Header: View, Footer: View, Content: View>: View {
+public struct VGRSection<Header: View, Footer: View, Content: View>: View {
 
     private let headerTitle: String?
     private let footerTitle: String?
@@ -116,7 +116,7 @@ struct VGRSection<Header: View, Footer: View, Content: View>: View {
         self.content = content()
     }
 
-    var body: some View {
+    public var body: some View {
         VStack(alignment: .leading, spacing: .Margins.medium) {
             if let headerTitle {
                 Group {

--- a/Sources/DesignSystem/Views/Lists/VGRSelectRow.swift
+++ b/Sources/DesignSystem/Views/Lists/VGRSelectRow.swift
@@ -22,7 +22,7 @@ import SwiftUI
 ///     VGRSelectRow(title: item.title, isSelected: selectedId == item.id)
 /// }
 /// ```
-struct VGRSelectRow<Icon: View>: View {
+public struct VGRSelectRow<Icon: View>: View {
 
     /// The primary text shown on the row.
     var title: String
@@ -65,7 +65,7 @@ struct VGRSelectRow<Icon: View>: View {
         self.icon = EmptyView()
     }
 
-    var body: some View {
+    public var body: some View {
         VGRListRow(title: title,
                    subtitle: subtitle,
                    icon: {


### PR DESCRIPTION
Promote the remaining Lists primitives to public access so consuming apps can use them: VGRContainer, VGRSection, VGRList, VGRListRow, VGRNavRow, VGRCheckRow and VGRSelectRow. Both the struct declaration and the body property are made public; stored properties remain internal as implementation detail.

VGRLabelRow, VGRToggleRow and VGRMenuRow were already public.