### PR TITLE
Add vgrTimeFormat and vgrTimeA11yFormat helpers

### DIFF
--- a/Sources/DesignSystem/Assets/sv.lproj/Localizable.strings
+++ b/Sources/DesignSystem/Assets/sv.lproj/Localizable.strings
@@ -14,6 +14,8 @@
 "general.warning" = "Varning";
 "general.button.done" = "Klar";
 "general.button.ok" = "OK";
+"general.time.at" = "Klockan";
+"general.time.at.short" = "Kl";
 
 /* Toggle */
 "toggle.a11y.hint" = "Dubbeltryck för att slå";

--- a/Sources/DesignSystem/Extensions/Date+Extensions.swift
+++ b/Sources/DesignSystem/Extensions/Date+Extensions.swift
@@ -150,16 +150,29 @@ public extension Date {
         return "Vecka " + self.formatted(.dateTime.week()) + ", " + self.formatted(.dateTime.year())
     }
 
+    /// vgrTimeFormat formats a time with a short localized "at" prefix (e.g. "Kl 14:30")
+    var vgrTimeFormat: String {
+        return "\("general.time.at.short".localizedBundle) \(self.formatted(date: .omitted, time: .shortened))"
+    }
+
+    /// vgrTimeA11yFormat formats a time with a fully spelled-out localized "at" prefix for VoiceOver (e.g. "Klockan 14:30")
+    var vgrTimeA11yFormat: String {
+        return "\("general.time.at".localizedBundle) \(self.formatted(date: .omitted, time: .shortened))"
+    }
+
+    /// vgrShortTimeFormat formats a time using the locale's short time style, with no prefix
     var vgrShortTimeFormat: String {
         return self.formatted(date: .omitted, time: .shortened)
     }
 
+    /// vgrDateTimeFormat combines vgrDateFormat and vgrShortTimeFormat, separated by a space
     var vgrDateTimeFormat: String {
         return "\(self.vgrDateFormat) \(self.vgrShortTimeFormat)"
     }
 
+    /// vgrDateTimeA11yFormat combines vgrDateFormat and vgrShortTimeFormat with a lowercased localized "at" connector, intended for VoiceOver
     var vgrDateTimeA11yFormat: String {
-        return "\(self.vgrDateFormat) \("general.time.at".localized.lowercased()) \(self.vgrShortTimeFormat)"
+        return "\(self.vgrDateFormat) \("general.time.at".localizedBundle.lowercased()) \(self.vgrShortTimeFormat)"
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds `vgrTimeFormat` (e.g. `Kl 14:30`) and `vgrTimeA11yFormat` (e.g. `Klockan 14:30`) on `Date`, both backed by `.shortened` time formatting.
- Introduces `general.time.at` / `general.time.at.short` localization keys so the prefixes are no longer hardcoded Swedish strings, and aligns `vgrDateTimeA11yFormat` to use `localizedBundle`.
- Adds `///` doc comments to the previously undocumented format properties (`vgrShortTimeFormat`, `vgrDateTimeFormat`, `vgrDateTimeA11yFormat`).

## Test plan
- [x] Build the package in Xcode
- [x] Verify `Date().vgrTimeFormat` renders `Kl HH:mm` in `sv` locale
- [x] Verify `Date().vgrTimeA11yFormat` renders `Klockan HH:mm` in `sv` locale
- [x] Verify `vgrDateTimeA11yFormat` still renders date + lowercased "klockan" + time