### PR TITLE
Add .tonal variant; environment-driven isEnabled; bare button style

### DIFF
--- a/Sources/DesignSystem/Views/Buttons/Button/V2/VGRButtonV2.swift
+++ b/Sources/DesignSystem/Views/Buttons/Button/V2/VGRButtonV2.swift
@@ -28,6 +28,9 @@ public enum VGRButtonV2Variant {
     /// Huvudåtgärd på färgad yta — inverterade färger.
     case primaryInverted
 
+    /// Tonad åtgärd — mjuk tintad yta med actionfärgad text.
+    case tonal
+
     /// Alternativ åtgärd — konturstil.
     case secondary
 
@@ -47,6 +50,7 @@ public enum VGRButtonV2Variant {
         switch self {
             case .primary:           return VGRButtonV2PrimaryVariant()
             case .primaryInverted:   return VGRButtonV2PrimaryInvertedVariant()
+            case .tonal:             return VGRButtonV2TonalVariant()
             case .secondary:         return VGRButtonV2SecondaryVariant()
             case .secondaryInverted: return VGRButtonV2SecondaryInvertedVariant()
             case .inline:            return VGRButtonV2InlineVariant()
@@ -86,9 +90,10 @@ public enum VGRButtonV2Variant {
 /// - Note: Under utveckling. Kommer att ersätta ``VGRButton`` när migreringen är klar.
 public struct VGRButtonV2<Icon: View>: View {
 
+    @Environment(\.isEnabled) private var isEnabled
+
     private let label: String
     private let variant: any VGRButtonV2VariantProtocol
-    @Binding private var isEnabled: Bool
     private let fullWidth: Bool
     private let size: VGRButtonV2Size
     private let accessibilityHint: String
@@ -101,7 +106,6 @@ public struct VGRButtonV2<Icon: View>: View {
     ///   - label: Knappens textetikett.
     ///   - variant: Visuell variant. Defaultar till `.primary`.
     ///   - size: Storleksskala. Defaultar till `.medium`.
-    ///   - isEnabled: Binding som styr om knappen är klickbar.
     ///   - fullWidth: Om `true` fyller knappen hela tillgängliga bredden.
     ///     Om `false` hugger knappen sitt innehåll. Defaultar till `true`.
     ///   - accessibilityHint: VoiceOver-hint som beskriver åtgärden.
@@ -110,11 +114,13 @@ public struct VGRButtonV2<Icon: View>: View {
     ///   - action: Closure som körs när knappen trycks.
     ///   - icon: Valfri ikon som vybyggare. Defaultar till tom vy. Ignoreras
     ///     när `systemImage` är satt.
+    ///
+    /// Aktivt/inaktivt-läge styrs via SwiftUIs `.disabled(_:)` modifier,
+    /// som propagerar genom `\.isEnabled` i environment.
     public init(
         _ label: String,
         variant: VGRButtonV2Variant = .primary,
         size: VGRButtonV2Size = .medium,
-        isEnabled: Binding<Bool> = .constant(true),
         fullWidth: Bool = true,
         accessibilityHint: String = "",
         systemImage: String? = nil,
@@ -123,7 +129,6 @@ public struct VGRButtonV2<Icon: View>: View {
     ) {
         self.label = label
         self.variant = variant.resolve()
-        self._isEnabled = isEnabled
         self.fullWidth = fullWidth
         self.size = size
         self.accessibilityHint = accessibilityHint
@@ -140,7 +145,6 @@ public struct VGRButtonV2<Icon: View>: View {
     ///   - customVariant: En instans av en typ som uppfyller
     ///     ``VGRButtonV2VariantProtocol``.
     ///   - size: Storleksskala. Defaultar till `.medium`.
-    ///   - isEnabled: Binding som styr om knappen är klickbar.
     ///   - fullWidth: Om `true` fyller knappen hela tillgängliga bredden.
     ///     Om `false` omsluter knappen sitt innehåll. Defaultar till `true`.
     ///   - accessibilityHint: VoiceOver-hint som beskriver åtgärden.
@@ -149,11 +153,13 @@ public struct VGRButtonV2<Icon: View>: View {
     ///   - action: Closure som körs när knappen trycks.
     ///   - icon: Valfri ikon som vybyggare. Defaultar till tom vy. Ignoreras
     ///     när `systemImage` är satt.
+    ///
+    /// Aktivt/inaktivt-läge styrs via SwiftUIs `.disabled(_:)` modifier,
+    /// som propagerar genom `\.isEnabled` i environment.
     public init(
         _ label: String,
         customVariant: any VGRButtonV2VariantProtocol,
         size: VGRButtonV2Size = .medium,
-        isEnabled: Binding<Bool> = .constant(true),
         fullWidth: Bool = true,
         accessibilityHint: String = "",
         systemImage: String? = nil,
@@ -162,7 +168,6 @@ public struct VGRButtonV2<Icon: View>: View {
     ) {
         self.label = label
         self.variant = customVariant
-        self._isEnabled = isEnabled
         self.fullWidth = fullWidth
         self.size = size
         self.accessibilityHint = accessibilityHint
@@ -207,6 +212,11 @@ public struct VGRButtonV2<Icon: View>: View {
             VGRSection(header: "Primary") {
                 VGRButtonV2("Medium", variant: .primary, size: .medium, systemImage: "tray.and.arrow.down") { }
                 VGRButtonV2("Small",  variant: .primary, size: .small,  systemImage: "tray.and.arrow.down") { }
+            }
+
+            VGRSection(header: "Tonal") {
+                VGRButtonV2("Medium", variant: .tonal, size: .medium, systemImage: "tray.and.arrow.down") { }
+                VGRButtonV2("Small",  variant: .tonal, size: .small,  systemImage: "tray.and.arrow.down") { }
             }
 
             VGRSection(header: "Secondary") {

--- a/Sources/DesignSystem/Views/Buttons/Button/V2/VGRButtonV2BareStyle.swift
+++ b/Sources/DesignSystem/Views/Buttons/Button/V2/VGRButtonV2BareStyle.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+/// Bar `ButtonStyle` utan default-chrome. Renderar bara label och en
+/// liten opacity-puff vid press. All visuell hantering av enabled/
+/// disabled lämnas till varianten — systemet lägger ingen dim på toppen.
+struct VGRButtonV2BareStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .opacity(configuration.isPressed ? 0.85 : 1.0)
+    }
+}

--- a/Sources/DesignSystem/Views/Buttons/Button/V2/VGRButtonV2DestructiveInlineVariant.swift
+++ b/Sources/DesignSystem/Views/Buttons/Button/V2/VGRButtonV2DestructiveInlineVariant.swift
@@ -22,7 +22,7 @@ public struct VGRButtonV2DestructiveInlineVariant: VGRButtonV2VariantProtocol {
             .contentShape(RoundedRectangle(cornerRadius: .Radius.mainRadius))
             .opacity(configuration.isEnabled ? 1 : 0.5)
         }
-        .buttonStyle(.plain)
+        .buttonStyle(VGRButtonV2BareStyle())
         .disabled(!configuration.isEnabled)
     }
 }

--- a/Sources/DesignSystem/Views/Buttons/Button/V2/VGRButtonV2DestructiveVariant.swift
+++ b/Sources/DesignSystem/Views/Buttons/Button/V2/VGRButtonV2DestructiveVariant.swift
@@ -21,7 +21,7 @@ public struct VGRButtonV2DestructiveVariant: VGRButtonV2VariantProtocol {
             .clipShape(RoundedRectangle(cornerRadius: .Radius.mainRadius))
             .opacity(configuration.isEnabled ? 1 : 0.5)
         }
-        .buttonStyle(.plain)
+        .buttonStyle(VGRButtonV2BareStyle())
         .disabled(!configuration.isEnabled)
     }
 }

--- a/Sources/DesignSystem/Views/Buttons/Button/V2/VGRButtonV2InlineVariant.swift
+++ b/Sources/DesignSystem/Views/Buttons/Button/V2/VGRButtonV2InlineVariant.swift
@@ -15,7 +15,7 @@ public struct VGRButtonV2InlineVariant: VGRButtonV2VariantProtocol {
             }
             .foregroundStyle(Color.Primary.action)
             .padding(.horizontal, configuration.size.padding)
-            .padding(.vertical, configuration.size.verticalPadding)
+            .padding(.vertical, configuration.size.verticalPadding + .Margins.small / 2)
             .applyFullWidth(configuration.fullWidth, alignment: .leading)
             .background(
                 RoundedRectangle(cornerRadius: .Radius.mainRadius)
@@ -24,7 +24,7 @@ public struct VGRButtonV2InlineVariant: VGRButtonV2VariantProtocol {
             .contentShape(RoundedRectangle(cornerRadius: .Radius.mainRadius))
             .opacity(configuration.isEnabled ? 1 : 0.5)
         }
-        .buttonStyle(.plain)
+        .buttonStyle(VGRButtonV2BareStyle())
         .disabled(!configuration.isEnabled)
     }
 }

--- a/Sources/DesignSystem/Views/Buttons/Button/V2/VGRButtonV2PrimaryInvertedVariant.swift
+++ b/Sources/DesignSystem/Views/Buttons/Button/V2/VGRButtonV2PrimaryInvertedVariant.swift
@@ -26,7 +26,7 @@ public struct VGRButtonV2PrimaryInvertedVariant: VGRButtonV2VariantProtocol {
             )
             .contentShape(RoundedRectangle(cornerRadius: .Radius.mainRadius))
         }
-        .buttonStyle(.plain)
+        .buttonStyle(VGRButtonV2BareStyle())
         .allowsHitTesting(configuration.isEnabled)
     }
 }
@@ -63,14 +63,14 @@ public struct VGRButtonV2PrimaryInvertedVariant: VGRButtonV2VariantProtocol {
                     }
 
                     VGRButtonV2(isEnabled ? "Aktiverad" : "Inaktiverad",
-                                variant: .primaryInverted,
-                                isEnabled: $isEnabled) { }
+                                variant: .primaryInverted) { }
+                        .disabled(!isEnabled)
 
                     VGRButtonV2(isEnabled ? "Aktiverad" : "Inaktiverad",
                                 variant: .primaryInverted,
                                 size: .medium,
-                                isEnabled: $isEnabled,
                                 systemImage: "tray.and.arrow.down") { }
+                        .disabled(!isEnabled)
 
                 }
             }

--- a/Sources/DesignSystem/Views/Buttons/Button/V2/VGRButtonV2SecondaryInvertedVariant.swift
+++ b/Sources/DesignSystem/Views/Buttons/Button/V2/VGRButtonV2SecondaryInvertedVariant.swift
@@ -27,7 +27,7 @@ public struct VGRButtonV2SecondaryInvertedVariant: VGRButtonV2VariantProtocol {
             )
             .contentShape(RoundedRectangle(cornerRadius: .Radius.mainRadius))
         }
-        .buttonStyle(.plain)
+        .buttonStyle(VGRButtonV2BareStyle())
         .disabled(!configuration.isEnabled)
     }
 }
@@ -64,8 +64,8 @@ public struct VGRButtonV2SecondaryInvertedVariant: VGRButtonV2VariantProtocol {
                     }
 
                     VGRButtonV2(isEnabled ? "Aktiverad" : "Inaktiverad",
-                                variant: .secondaryInverted,
-                                isEnabled: $isEnabled) { }
+                                variant: .secondaryInverted) { }
+                        .disabled(!isEnabled)
                 }
             }
 

--- a/Sources/DesignSystem/Views/Buttons/Button/V2/VGRButtonV2SecondaryVariant.swift
+++ b/Sources/DesignSystem/Views/Buttons/Button/V2/VGRButtonV2SecondaryVariant.swift
@@ -24,7 +24,7 @@ public struct VGRButtonV2SecondaryVariant: VGRButtonV2VariantProtocol {
             )
             .contentShape(RoundedRectangle(cornerRadius: .Radius.mainRadius))
         }
-        .buttonStyle(.plain)
+        .buttonStyle(VGRButtonV2BareStyle())
         .disabled(!configuration.isEnabled)
     }
 }
@@ -48,13 +48,13 @@ public struct VGRButtonV2SecondaryVariant: VGRButtonV2VariantProtocol {
                 }
 
                 VGRButtonV2(isEnabled ? "Aktiverad" : "Inaktiverad",
-                            variant: .secondary,
-                            isEnabled: $isEnabled) { }
+                            variant: .secondary) { }
+                    .disabled(!isEnabled)
                 VGRButtonV2(isEnabled ? "Aktiverad" : "Inaktiverad",
-                            variant: .secondary,
-                            isEnabled: $isEnabled) { } icon: {
+                            variant: .secondary) { } icon: {
                     Image(systemName: "tray.and.arrow.down")
                 }
+                .disabled(!isEnabled)
             }
 
             VGRSection(header: "Sizes") {

--- a/Sources/DesignSystem/Views/Buttons/Button/V2/VGRButtonV2TonalVariant.swift
+++ b/Sources/DesignSystem/Views/Buttons/Button/V2/VGRButtonV2TonalVariant.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
-/// Primär knappvariant — fylld actionfärg, centrerad headline, fyller bredden.
-public struct VGRButtonV2PrimaryVariant: VGRButtonV2VariantProtocol {
+/// Tonal knappvariant — tonad actionfärg på mjuk surface, centrerad headline, fyller bredden.
+public struct VGRButtonV2TonalVariant: VGRButtonV2VariantProtocol {
     public init() {}
 
     public func makeBody(configuration: Configuration) -> some View {
@@ -14,14 +14,16 @@ public struct VGRButtonV2PrimaryVariant: VGRButtonV2VariantProtocol {
                     .font(configuration.size.font)
             }
             .foregroundStyle(configuration.isEnabled ?
-                             Color.Neutral.textInverted :
-                                Color.Neutral.disabledVariant)
+                             Color.Primary.action :
+                                Color.Neutral.disabled)
             .padding(.horizontal, configuration.size.padding)
             .padding(.vertical, configuration.size.verticalPadding)
             .applyFullWidth(configuration.fullWidth)
             .background(
                 RoundedRectangle(cornerRadius: .Radius.mainRadius)
-                    .fill(configuration.isEnabled ? Color.Primary.action : Color.Neutral.disabled)
+                    .fill(
+                        configuration.isEnabled ? Color.Primary.blueSurfaceMinimal : Color.Neutral.disabledVariant
+                    )
             )
             .contentShape(RoundedRectangle(cornerRadius: .Radius.mainRadius))
         }
@@ -30,15 +32,15 @@ public struct VGRButtonV2PrimaryVariant: VGRButtonV2VariantProtocol {
     }
 }
 
-#Preview("Primary") {
+#Preview("Tonal") {
     @Previewable @State var isEnabled: Bool = false
 
     NavigationStack {
         VGRContainer {
-            VGRSection(header: "Primary") {
-                VGRButtonV2("Spara") { }
+            VGRSection(header: "Tonal") {
+                VGRButtonV2("Spara", variant: .tonal) { }
 
-                VGRButtonV2("Spara med ikon") { } icon: {
+                VGRButtonV2("Spara med ikon", variant: .tonal) { } icon: {
                     Image(systemName: "tray.and.arrow.down")
                 }
             }
@@ -48,31 +50,41 @@ public struct VGRButtonV2PrimaryVariant: VGRButtonV2VariantProtocol {
                     VGRToggleRow(title: "State", isOn: $isEnabled)
                 }
 
-                VGRButtonV2(isEnabled ? "Aktiverad" : "Inaktiverad") { }
+                VGRButtonV2(isEnabled ? "Aktiverad" : "Inaktiverad",
+                            variant: .tonal) { }
                     .disabled(!isEnabled)
-                VGRButtonV2(isEnabled ? "Aktiverad" : "Inaktiverad") { } icon: {
+                VGRButtonV2(isEnabled ? "Aktiverad" : "Inaktiverad",
+                            variant: .tonal) { } icon: {
                     Image(systemName: "tray.and.arrow.down")
                 }
                 .disabled(!isEnabled)
             }
 
             VGRSection(header: "Sizes") {
-                VGRButtonV2("Medium", size: .medium, systemImage: "tray.and.arrow.down") { }
-                VGRButtonV2("Small",  size: .small,  systemImage: "tray.and.arrow.down") { }
+                VGRButtonV2("Medium", variant: .tonal, size: .medium, systemImage: "tray.and.arrow.down") { }
+                VGRButtonV2("Small",  variant: .tonal, size: .small,  systemImage: "tray.and.arrow.down") { }
             }
 
             VGRSection(header: "systemImage") {
-                VGRButtonV2("Ladda ner", systemImage: "square.and.arrow.down") { }
+                VGRButtonV2("Ladda ner", variant: .tonal, systemImage: "square.and.arrow.down") { }
             }
 
             VGRSection(header: "Hug content (fullWidth: false)") {
                 HStack(spacing: .Margins.small) {
-                    VGRButtonV2("Spara", fullWidth: false) { }
-                    VGRButtonV2("Small", size: .small, fullWidth: false) { }
+                    VGRButtonV2("Spara", variant: .tonal, fullWidth: false) { }
+                    VGRButtonV2(
+                        "Small",
+                        variant: .tonal,
+                        size: .small,
+                        fullWidth: false,
+                        systemImage: "gearshape"
+                    ) {
+
+                    }
                 }
                 .frame(maxWidth: .infinity, alignment: .center)
             }
         }
-        .navigationTitle("Primary")
+        .navigationTitle("Tonal")
     }
 }


### PR DESCRIPTION
## Summary
- New `.tonal` variant on `VGRButtonV2` — soft tinted surface (`Color.Primary.blueSurfaceMinimal`) with action-coloured text/icon, mirrors primary's structure.
- Drops the `isEnabled: Binding<Bool>` parameter from `VGRButtonV2`'s public API in favour of SwiftUI's `\.isEnabled` environment value. Callers now use the standard `.disabled(_:)` modifier.
- Replaces `.buttonStyle(.plain)` with a new internal `VGRButtonV2BareStyle` across all variants so the system stops layering its default disabled dim on top of variant-controlled colours. Each variant is now the single source of truth for its disabled appearance.

## Notes
- This is a breaking change to `VGRButtonV2`'s init signature — the `isEnabled:` argument is gone. Sibling apps consuming the design system will need to migrate any `isEnabled: $foo` call sites to `.disabled(!foo)`.
- To force a button enabled inside a `.disabled(true)` ancestor, use `.environment(\.isEnabled, true)` (SwiftUI's `.disabled(_:)` is intentionally one-way).

## Test plan
- [x] Open the "All variants" preview in `VGRButtonV2.swift` — confirm `.tonal` renders alongside the existing variants in light & dark mode.
- [x] Open each variant's individual preview — confirm enabled/disabled toggling works via `.disabled(!isEnabled)` and that disabled appearance matches the variant's intent (no extra system dim).
- [x] Wrap a `VGRButtonV2` in `.disabled(true)` and verify the variant's disabled colours apply with no system overlay.
- [x] Verify press feedback (subtle opacity bump) still works.