### PR TITLE
Add VGREditButton toolbar button

### DIFF
--- a/Sources/DesignSystem/Assets/sv.lproj/Localizable.strings
+++ b/Sources/DesignSystem/Assets/sv.lproj/Localizable.strings
@@ -2,6 +2,7 @@
 "general.cancel" = "Avbryt";
 "general.done" = "Klar";
 "general.close" = "Stäng";
+"general.edit" = "Ändra";
 "general.decrease" = "Minska";
 "general.increase" = "Öka";
 "general.selected" = "Vald";

--- a/Sources/DesignSystem/Views/Buttons/Toolbar/VGREditButton.swift
+++ b/Sources/DesignSystem/Views/Buttons/Toolbar/VGREditButton.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+
+/// Toolbar button labelled "Ändra" (Edit) for entering edit mode.
+/// SwiftUI has no `.edit` `ButtonRole`, so this renders a plain text button
+/// in `Color.Primary.action` rather than a system-provided role glyph.
+public struct VGREditButton: View {
+    @Environment(\.isEnabled) private var isEnabled
+    let action: () -> Void
+
+    public init(action: @escaping () -> Void) {
+        self.action = action
+    }
+
+    public var body: some View {
+        Button {
+            action()
+        } label: {
+            Text("general.edit".localizedBundle)
+                .foregroundStyle(isEnabled ? Color.Primary.action : Color.Neutral.disabled)
+        }
+        .disabled(!isEnabled)
+    }
+}
+
+#Preview {
+    @Previewable @State var showSheet: Bool = false
+
+    VStack(spacing: 32) {
+        Text("This is the edit button in a ordinary context")
+        VGREditButton {
+            print("Editing")
+            showSheet.toggle()
+        }
+
+        Text("Disabled state")
+        VGREditButton {
+            print("Editing")
+            showSheet.toggle()
+        }
+        .disabled(true)
+    }
+    .padding()
+    .sheet(isPresented: $showSheet) {
+        NavigationStack {
+            Text("Sheet is open, look how nice the editbutton looks in the navigationbar.")
+                .padding()
+                .navigationTitle("Sheet")
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        VGREditButton {
+                            showSheet.toggle()
+                        }
+                    }
+                    ToolbarItem(placement: .navigationBarLeading) {
+                        VGREditButton {
+                            showSheet.toggle()
+                        }
+                        .disabled(true)
+                    }
+                }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- New `VGREditButton` toolbar button labelled "Ändra", styled like the other toolbar buttons (`Color.Primary.action`, environment-driven `isEnabled`).
- Adds `general.edit` to `sv.lproj/Localizable.strings`.

Note: SwiftUI has no `.edit` `ButtonRole`, so unlike `VGRCancelButton`/`VGRCloseButton`/`VGRDoneButton` this is a plain text button on all iOS versions. The action is non-optional since there's no `@Environment(\.dismiss)` equivalent to fall back on.

## Test plan
- [x] Open the `VGREditButton` preview and confirm enabled/disabled states
- [x] Confirm the button renders correctly in a `NavigationStack` toolbar (leading + trailing)