### PR TITLE
Add VGRSectionTitle with size variants and accessory slot

### DIFF
--- a/Sources/DesignSystem/Extensions/CGFloat+ThemeValues.swift
+++ b/Sources/DesignSystem/Extensions/CGFloat+ThemeValues.swift
@@ -2,26 +2,51 @@ import Foundation
 
 public extension CGFloat {
 
+    /// Corner radius tokens used across the design system.
     enum Radius {
+        /// `26 pt` — primary corner radius used for cards and most rounded surfaces.
         public static let mainRadius: CGFloat = 26
+
+        /// `62 pt` — screen-level corner radius for full-screen containers.
         public static let screen: CGFloat = 62
+
+        /// `38 pt` — large corner radius.
         public static let large38: CGFloat = 38
+
+        /// `40 pt` — VGR-branded corner radius.
         public static let vgrCorner: CGFloat = 40
+
+        /// `8 pt` — small corner radius.
         public static let smallSchema: CGFloat = 8
     }
 
+    /// Spacing tokens used for padding, margins, and stack spacing.
     enum Margins {
+        /// `32 pt` — extra-large spacing step.
         public static let xtraLarge: CGFloat = 32
+
+        /// `24 pt` — large spacing step.
         public static let large: CGFloat = 24
+
+        /// `16 pt` — medium spacing step. The default for most layouts.
         public static let medium: CGFloat = 16
+
+        /// `12 pt` — small spacing step.
         public static let small: CGFloat = 12
+
+        /// `8 pt` — extra-small spacing step.
         public static let xtraSmall: CGFloat = 8
 
+        /// `16 pt` — horizontal inset used for safe-area edges.
         public static let safeArea: CGFloat = 16
     }
 
+    /// Letter-spacing (tracking) tokens applied to text.
     enum Letterspacing {
+        /// `0.2` — small tracking adjustment.
         public static let small: CGFloat = 0.2
+
+        /// `0.0` — neutral tracking (no adjustment).
         public static let medium: CGFloat = 0.0
     }
 

--- a/Sources/DesignSystem/Views/Lists/VGRSection.swift
+++ b/Sources/DesignSystem/Views/Lists/VGRSection.swift
@@ -160,6 +160,23 @@ public struct VGRSection<Header: View, Footer: View, Content: View>: View {
                 }
             }
 
+            VGRSection {
+                VGRList {
+                    VGRListRow(title: "Title", subtitle: "Subtitle")
+                }
+            } header: {
+                VGRSectionTitle(
+                    "Header only",
+                    description: "A short explanatory text",
+                    variant: .small
+                ) {
+                    Image(systemName: "star.fill")
+                        .resizable()
+                        .frame(width: 25, height: 25)
+                        .maxTrailing()
+                }
+            }
+
             VGRSection(header: "Header and footer",
                        footer: "A short explanatory note that can wrap across multiple lines if needed.") {
                 VGRList {

--- a/Sources/DesignSystem/Views/Lists/VGRSectionTitle.swift
+++ b/Sources/DesignSystem/Views/Lists/VGRSectionTitle.swift
@@ -1,0 +1,184 @@
+import SwiftUI
+
+/// A heading view intended for the `header` slot of a ``VGRSection``.
+///
+/// Renders a title with an optional supporting description, plus an optional
+/// trailing accessory slot for actions such as buttons. The size of the
+/// heading and the spacing between title and description are controlled by
+/// ``Variant``.
+///
+/// ```swift
+/// VGRSection {
+///     VGRList { ... }
+/// } header: {
+///     VGRSectionTitle("Settings", description: "Manage your preferences")
+/// }
+/// ```
+///
+/// To add a trailing action, use the accessory view builder:
+///
+/// ```swift
+/// VGRSectionTitle("Settings", description: "Manage your preferences") {
+///     VGRButtonV2("Edit", variant: .tonal, fullWidth: false) { … }
+///         .maxTrailing()
+/// }
+/// ```
+public struct VGRSectionTitle<Accessory: View>: View {
+
+    /// Visual size variants for ``VGRSectionTitle``.
+    ///
+    /// Each case bundles a title font, a description font, and the spacing
+    /// between the two text rows.
+    public enum Variant {
+        /// Compact heading for tightly packed sections.
+        case small
+        /// Standard size used for most sections.
+        case `default`
+        /// Extra breathing room between title and description.
+        case spacey
+
+        var titleFont: Font {
+            switch self {
+                case .small: .headlineSemibold
+                case .default: .title3Semibold
+                case .spacey: .title3Semibold
+            }
+        }
+
+        var descriptionFont: Font {
+            switch self {
+                case .small: .subheadline
+                case .default: .subheadline
+                case .spacey: .subheadline
+            }
+        }
+
+        var spacing: CGFloat {
+            switch self {
+                case .small: 0
+                case .default: 0
+                case .spacey: .Margins.small
+            }
+        }
+    }
+
+    let title: String
+    let description: String
+    let variant: Variant
+    let accessory: Accessory
+
+    /// Creates a section title with a trailing accessory view.
+    ///
+    /// Use the no-accessory convenience initializer when you don't need a
+    /// trailing view — it omits the builder entirely.
+    ///
+    /// - Parameters:
+    ///   - title: The section heading text.
+    ///   - description: Supporting text rendered below the title. Hidden when empty.
+    ///   - variant: The size variant. Defaults to ``Variant/default``.
+    ///   - accessory: A trailing view rendered alongside the heading. Typically
+    ///     a small button or icon.
+    public init(_ title: String,
+                description: String = "",
+                variant: Variant = .default,
+                @ViewBuilder accessory: () -> Accessory) {
+        self.title = title
+        self.description = description
+        self.variant = variant
+        self.accessory = accessory()
+    }
+
+
+    public var body: some View {
+        HStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: variant.spacing) {
+                Text(title)
+                    .font(variant.titleFont)
+
+                if !description.isEmpty {
+                    Text(description)
+                        .font(variant.descriptionFont)
+                }
+            }
+
+            accessory
+        }
+        .maxLeading()
+        .foregroundStyle(Color.Neutral.text)
+        .padding(.horizontal, .Margins.medium)
+    }
+}
+
+extension VGRSectionTitle where Accessory == EmptyView {
+    /// Creates a section title without a trailing accessory.
+    public init(_ title: String, description: String = "", variant: Variant = .default) {
+        self.init(title, description: description, variant: variant, accessory: { EmptyView() })
+    }
+}
+
+#Preview {
+    NavigationStack {
+        VGRContainer {
+            VGRSection {
+                VGRList {
+                    VGRLabelRow("Label", value: "Value")
+                    VGRLabelRow("Label", value: "Value")
+                }
+            } header: {
+                VGRSectionTitle("Small variant", description: "Alfa beta gamma delta", variant: .small)
+            }
+
+            VGRSection {
+                VGRList {
+                    VGRLabelRow("Label", value: "Value")
+                    VGRLabelRow("Label", value: "Value")
+                }
+            } header: {
+                VGRSectionTitle("Default variant", description: "Alfa beta gamma delta")
+            }
+
+            VGRSection {
+                VGRList {
+                    VGRLabelRow("Label", value: "Value")
+                    VGRLabelRow("Label", value: "Value")
+                }
+            } header: {
+                VGRSectionTitle("Spacey variant", description: "Alfa beta gamma delta", variant: .spacey)
+            }
+
+            VGRSection {
+                VGRList {
+                    VGRLabelRow("Label", value: "Value")
+                }
+            } header: {
+                VGRSectionTitle("A considerably longer title that should wrap onto several lines so we can see how the section header handles overflowing headline text",
+                                description: "Short description")
+            }
+
+            VGRSection {
+                VGRList {
+                    VGRLabelRow("Label", value: "Value")
+                }
+            } header: {
+                VGRSectionTitle("Short title",
+                                description: "A considerably longer description that should wrap onto several lines so we can see how the section header handles overflowing supporting text without breaking the layout of the rest of the section")
+            }
+
+            VGRSection {
+                VGRList {
+                    VGRLabelRow("Label", value: "Value")
+                }
+            } header: {
+                VGRSectionTitle("With accessory", description: "Alfa beta gamma delta") {
+                    VGRButtonV2("Knapp",
+                                variant: .tonal,
+                                fullWidth: false,
+                                systemImage: "gearshape") { print("action") }
+                        .maxTrailing()
+                }
+            }
+        }
+        .navigationTitle("VGRSectionTitle")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}


### PR DESCRIPTION
Introduces VGRSectionTitle, a header view for VGRSection with three size variants (small, default, spacey) and an optional trailing accessory slot for actions such as buttons. Adds DocC documentation to the new component, and also documents the existing CGFloat theme tokens (Radius, Margins, Letterspacing) so callers can read the underlying values directly from Xcode Quick Help without navigating to source.