### PR TITLE
Add warningColor property to VGRValidationLabel

### DIFF
--- a/Sources/DesignSystem/Views/Labels/VGRValidationLabel.swift
+++ b/Sources/DesignSystem/Views/Labels/VGRValidationLabel.swift
@@ -2,7 +2,10 @@ import SwiftUI
 
 /// En valideringsetikett som visar ett textmeddelande med ett valfritt varningsläge.
 /// I standardläge visas texten i neutral stil. När `isWarning` är `true` visas en varningsikon
-/// och texten färgas i felstil för att uppmärksamma användaren på ett valideringsfel.
+/// och texten färgas i `warningColor` (standard `Color.Status.errorText`) för att uppmärksamma
+/// användaren på ett valideringsfel. Använd `warningColor` när varningen i sammanhanget
+/// uttrycker en uppmaning snarare än ett fel — t.ex. för att matcha en omslutande
+/// ``VGRList`` med en annan `borderColor`.
 ///
 /// ### Användning
 /// ```swift
@@ -11,18 +14,29 @@ import SwiftUI
 ///
 /// // Varningsläge — valideringsfel
 /// VGRValidationLabel("Välj minst ett alternativ", isWarning: true)
+///
+/// // Varningsläge med anpassad färg — uppmaning snarare än fel
+/// VGRValidationLabel("Välj en annan tid",
+///                    isWarning: true,
+///                    warningColor: Color.Primary.action)
 /// ```
 public struct VGRValidationLabel: View {
     let text: LocalizedStringKey
     let isWarning: Bool
+    let warningColor: Color
 
     /// Initierar en `VGRValidationLabel` med angiven text och valfritt varningsläge.
     /// - Parameters:
     ///   - text: Den lokaliserade texten som visas i etiketten.
     ///   - isWarning: Anger om etiketten ska visas i varningsläge med felstil och ikon. Standard är `false`.
-    public init(_ text: LocalizedStringKey, isWarning: Bool = false) {
+    ///   - warningColor: Färgen som används för text och ikon när `isWarning` är `true`.
+    ///     Standard är `Color.Status.errorText`.
+    public init(_ text: LocalizedStringKey,
+                isWarning: Bool = false,
+                warningColor: Color = Color.Status.errorText) {
         self.text = text
         self.isWarning = isWarning
+        self.warningColor = warningColor
     }
 
     public var body: some View {
@@ -37,7 +51,7 @@ public struct VGRValidationLabel: View {
         }
         .font(.footnoteRegular)
         .contentShape(Rectangle())
-        .foregroundStyle(isWarning ? Color.Status.errorText : Color.Neutral.text)
+        .foregroundStyle(isWarning ? warningColor : Color.Neutral.text)
         .accessibilityElement(children: .combine)
 
     }
@@ -47,6 +61,9 @@ public struct VGRValidationLabel: View {
     VStack(spacing: .Margins.medium) {
         VGRValidationLabel("Default state — no warning")
         VGRValidationLabel("Warning state — validation failed", isWarning: true)
+        VGRValidationLabel("Warning state — custom color",
+                           isWarning: true,
+                           warningColor: Color.Primary.action)
     }
     .padding()
 }


### PR DESCRIPTION
## Summary
- Adds a `warningColor` parameter (default `Color.Status.errorText`) to `VGRValidationLabel`, replacing the hardcoded warning tint.
- Lets callers match the label's warning color to a surrounding `VGRList`'s `borderColor` when the validation reads as a prompt rather than a destructive error (e.g. copy-mode validation).
- Default value preserves existing behavior, so this is purely additive.

## Test plan
- [x] Open the `VGRValidationLabel` preview — verify the new "custom color" row paints in `Color.Primary.action`.
- [x] Verify the existing two rows (default + warning) look unchanged.
- [x] Spot-check an existing caller (no init-site change required) still compiles and renders the red warning.