### PR TITLE
Add Matomo event tracking, AppVersion dimension, and consent tracking

### DIFF
--- a/Sources/DesignSystem/Logic/Matomo/README.md
+++ b/Sources/DesignSystem/Logic/Matomo/README.md
@@ -1,0 +1,122 @@
+# Matomo Tracker
+
+A thin wrapper around `MatomoTracker`, exposed as the `Tracker.shared` singleton. Two things to know up front:
+
+- Nothing is sent unless the user is **opted in** (see [Consent](#consent)).
+- In the **simulator** nothing is sent — calls are logged to the console instead.
+
+## Setup
+
+`Tracker.shared` configures itself from the app's `Info.plist`. Add these keys (values are typically injected from an `.xcconfig`):
+
+| Key | Required | Description |
+|-----|----------|-------------|
+| `MATOMO_SITE_ID` | ✅ | The site ID in Matomo. |
+| `MATOMO_URL` | ✅ | Full URL to the Matomo endpoint, e.g. `https://example.org/matomo.php`. |
+| `MATOMO_APPVERSION_DIMENSION` | – | Index of a **Visit-scope** custom dimension that receives `CFBundleShortVersionString`. Create the dimension in the Matomo backend first, then set its index here. |
+
+```xml
+<key>MATOMO_SITE_ID</key>
+<string>$(MATOMO_SITE_ID)</string>
+<key>MATOMO_URL</key>
+<string>https://$(MATOMO_URL)</string>
+<key>MATOMO_APPVERSION_DIMENSION</key>
+<string>$(MATOMO_APPVERSION_DIMENSION)</string>
+```
+
+No manual init call is needed. On device, missing site ID / URL is a fatal misconfiguration.
+
+## Tracking views
+
+A **view** records *where* the user is. Model your screens as a `TrackableScreen`:
+
+> **Note:** Define **one `TrackableScreen` enum per app**, holding every screen as a case. It's the app's single, central catalogue of trackable screens.
+
+```swift
+enum AppScreen: TrackableScreen {
+    case home
+    case headache(action: TrackerAction)   // TrackerAction is built in
+
+    var identifier: String {
+        switch self {
+            case .home: return "home"
+            case .headache(let action): return "\(action.rawValue)_headache"
+        }
+    }
+}
+```
+
+Track on appear with the view modifier (preferred in SwiftUI):
+
+```swift
+SomeView()
+    .track(AppScreen.home)
+```
+
+…or call the tracker directly:
+
+```swift
+Tracker.shared.trackScreen(AppScreen.headache(action: .create))
+Tracker.shared.trackScreen(AppScreen.home, note: "from_deeplink")   // optional note
+Tracker.shared.trackOnceDaily(AppScreen.home)                        // at most once per calendar day
+```
+
+Something *triggered* like an action but that you still want recorded as its own view (e.g. a delete logged as `delete_medication`, not an event) uses `trackEvent(_:note:)`:
+
+```swift
+Tracker.shared.trackEvent(AppScreen.medication(action: .delete))     // still a view
+```
+
+## Tracking events
+
+An **event** records *what the user did within a screen*. Model interactions as a `TrackableInteraction` (each app owns its own vocabulary):
+
+> **Note:** Define **one `TrackableInteraction` enum per feature** (e.g. one for headaches, one for medication), each holding that feature's interactions. Unlike screens, interactions are scoped per feature rather than collected app-wide.
+
+```swift
+enum HeadacheInteraction: TrackableInteraction {
+    case addSymptom(String)   // name carries which symptom
+    case setPainLevel(Int)    // value carries the number
+
+    var action: String {
+        switch self {
+            case .addSymptom: return "add_symptom"
+            case .setPainLevel: return "set_pain_level"
+        }
+    }
+    var name: String? {
+        switch self {
+            case .addSymptom(let symptom): return symptom
+            case .setPainLevel: return nil
+        }
+    }
+    var value: Float? {
+        switch self {
+            case .setPainLevel(let level): return Float(level)
+            default: return nil
+        }
+    }
+}
+```
+
+Track it, passing the screen it happened on — **the screen supplies the event category**:
+
+```swift
+Tracker.shared.trackEvent(HeadacheInteraction.addSymptom("nausea"),
+                          on: AppScreen.headache(action: .create))
+// category=create_headache · action=add_symptom · name=nausea
+
+Tracker.shared.trackEvent(HeadacheInteraction.setPainLevel(7),
+                          on: AppScreen.headache(action: .create))
+// category=create_headache · action=set_pain_level · value=7
+```
+
+## Consent
+
+Nothing is tracked unless the user is opted in (defaults to opted-in on first launch):
+
+```swift
+Tracker.shared.setOptInSetting(false)   // opt out
+Tracker.shared.setOptInSetting(true)    // opt in
+Tracker.shared.isOptedIn                // current state
+```

--- a/Sources/DesignSystem/Logic/Matomo/Tracker.swift
+++ b/Sources/DesignSystem/Logic/Matomo/Tracker.swift
@@ -14,19 +14,29 @@ public class Tracker {
     init() {
         let matomoSiteId = Bundle.main.object(forInfoDictionaryKey:"MATOMO_SITE_ID") as? String ?? ""
         let matomoURL = Bundle.main.object(forInfoDictionaryKey:"MATOMO_URL") as? String ?? ""
+        let appVersionDimensionIndex = Int(Bundle.main.object(forInfoDictionaryKey:"MATOMO_APPVERSION_DIMENSION") as? String ?? "") ?? -1
+        let appVersion = Bundle.main.appVersionLong
 
 #if targetEnvironment(simulator)
-        print("📱 Tracker is running in simulated environment")
+        logger.info("📱 Tracker is running in simulated environment")
         matomoTracker = nil
 #else
         if matomoURL.isEmpty || matomoSiteId.isEmpty {
             fatalError("invalid configuration for analytics")
         }
 
+
         let url = URL(string: matomoURL)
         if let baseURL = url {
             let newTracker = MatomoTracker(siteId: matomoSiteId, baseURL: baseURL)
             newTracker.logger = DefaultLogger(minLevel: .info)
+
+            if appVersionDimensionIndex != -1 {
+                newTracker.setDimension(appVersion, forIndex: appVersionDimensionIndex)
+            } else {
+                logger.warning("no app version dimension set")
+            }
+
             matomoTracker = newTracker
         } else {
             fatalError("failed initializing tracker, invalid URL")
@@ -50,18 +60,12 @@ public class Tracker {
         // TODO: (ea) - Find a way to include voiceOver state in tracking
         // let isVoiceOverActive = UIAccessibility.isVoiceOverRunning
 
-        let isOptedIn = getOptInSetting()
-        if !isOptedIn {
-            return
-        }
+        guard getOptInSetting() else { return }
 
 #if targetEnvironment(simulator)
         /// When we're in a simulator environment (iOS Simulator & xcode preview), we do not actually call the tracker - just log it.
-        if let note {
-            print("👀 Tracker: \(screen.identifier), 🗒️ \"\(note)\"")
-        } else {
-            print("👀 Tracker: \(screen.identifier)")
-        }
+        let noteSuffix = note.map { ", 🗒️ \"\($0)\"" } ?? ""
+        logger.info("👀 Tracker: \(screen.identifier)\(noteSuffix)")
 #else
         guard let tracker = matomoTracker else { return }
         
@@ -70,6 +74,38 @@ public class Tracker {
         } else {
             tracker.track(view: [screen.identifier])
         }
+#endif
+    }
+
+    /// Tracks a user interaction that occurs within a screen.
+    ///
+    /// Unlike `trackScreen`, which records that a screen was viewed, this method records a
+    /// discrete interaction the user performed *while on* that screen — for example adding a
+    /// symptom or choosing a value. It is reported as a proper Matomo event: the screen supplies
+    /// the event category, and the interaction supplies the action, name, and value.
+    /// The tracking only occurs if the user has opted in to analytics.
+    ///
+    /// - Parameters:
+    ///   - interaction: The interaction to track, conforming to `TrackableInteraction`. Provides
+    ///     the event's action (`e_a`), and optionally its name (`e_n`) and value (`e_v`).
+    ///   - screen: The screen the interaction happened on, conforming to `TrackableScreen`. Its
+    ///     `identifier` is used as the event category (`e_c`).
+    public func trackEvent(_ interaction: TrackableInteraction, on screen: TrackableScreen) {
+        guard getOptInSetting() else { return }
+
+#if targetEnvironment(simulator)
+        /// When we're in a simulator environment (iOS Simulator & xcode preview), we do not actually call the tracker - just log it.
+        let n = interaction.name.map { " / \($0)" } ?? ""
+        let v = interaction.value.map { " = \($0)" } ?? ""
+        logger.info("⚡️ Event: \(screen.identifier) / \(interaction.action)\(n)\(v)")
+#else
+        guard let tracker = matomoTracker else { return }
+        tracker.track(
+            eventWithCategory: screen.identifier,   // ← your TrackableScreen, as the category
+            action: interaction.action,
+            name: interaction.name,
+            value: interaction.value
+        )
 #endif
     }
 
@@ -105,14 +141,24 @@ public class Tracker {
         UserDefaults.standard.set(now, forKey: lastTrackedKey)
     }
 
-    /// Tracks an event in the analytics system.
+    /// Tracks an action-triggered screen view in the analytics system.
     ///
-    /// This is a convenience method that internally calls `trackScreen`. Use this when
-    /// tracking user interactions or events rather than screen views.
+    /// - Note: Despite its name, this method registers the call as a **view**, not as a Matomo
+    ///   event. It is a thin convenience wrapper around `trackScreen`.
+    ///
+    /// Use this for things that are *triggered* like events in the app but that you want recorded
+    /// as their own self-contained view rather than as an action performed on another view. For
+    /// example, deleting a medication intake is logged as a single `"delete_medication"` view —
+    /// not as a `"delete"` action on a `"view_medication"` category.
+    ///
+    /// For interactions that should be recorded as true Matomo events (a category with a separate
+    /// action, name, and value), use `trackEvent(_:on:)` instead.
+    ///
+    /// The tracking only occurs if the user has opted in to analytics.
     ///
     /// - Parameters:
-    ///   - screen: The event to track, conforming to `TrackableScreen` protocol.
-    ///   - note: An optional additional note to include with the event tracking.
+    ///   - screen: The screen to track, conforming to `TrackableScreen` protocol.
+    ///   - note: An optional additional note to include with the tracking.
     public func trackEvent(_ screen: TrackableScreen, note: String? = nil) {
         trackScreen(screen, note: note)
     }
@@ -171,14 +217,45 @@ public class Tracker {
     /// This method updates both the UserDefaults preference and configures the underlying
     /// Matomo tracker accordingly. When the user opts out, no analytics data will be collected.
     ///
+    /// When the preference genuinely changes (a user-initiated toggle — not the re-application that
+    /// happens on every launch via `initTracker()`), a `consent` event carrying the new value is
+    /// reported. For an opt-**out** the event is tracked and flushed *before* `isOptedOut` is set:
+    /// once that flag is on, `MatomoTracker` discards every event at enqueue time, so the opt-out
+    /// could never otherwise be recorded. This is what lets us measure how many users disable
+    /// tracking.
+    ///
     /// - Parameter isOptedIn: `true` to enable analytics tracking, `false` to disable it.
     public func setOptInSetting(_ isOptedIn: Bool) {
+        /// Detect a genuine change *before* overwriting the stored value. `setOptInSetting` is also
+        /// called on every launch to re-apply the persisted setting, so reporting unconditionally
+        /// would massively over-count. `hasOptInSetting()` also excludes the first-launch default.
+        let didChange = hasOptInSetting() && getOptInSetting() != isOptedIn
+
         UserDefaults.standard.set(isOptedIn, forKey: personalDataAgreementAccepted)
+
         guard let tracker = matomoTracker else {
-            print("👀 Tracker is disabled: Opt-in setting should be set to '\(isOptedIn)'")
+            logger.info("👀 Tracker is disabled: Opt-in setting should be set to '\(isOptedIn)'")
             return
         }
-        tracker.isOptedOut = !isOptedIn
+
+        /// The consent event goes straight through the wrapped tracker, bypassing the public
+        /// tracking methods: their `getOptInSetting()` guard reads the value we just persisted,
+        /// which for an opt-out would suppress this very event.
+        if isOptedIn {
+            /// Enabling: lift the opt-out first so the event can be queued, then report the change.
+            tracker.isOptedOut = false
+            if didChange {
+                tracker.track(eventWithCategory: "consent", action: "opt_in", value: 1.0)
+            }
+        } else {
+            /// Disabling: report and flush the opt-out while still opted in, BEFORE isOptedOut is
+            /// set — afterwards `queue(event:)` would silently drop it.
+            if didChange {
+                tracker.track(eventWithCategory: "consent", action: "opt_out", value: 0.0)
+                tracker.dispatch()
+            }
+            tracker.isOptedOut = true
+        }
     }
 }
 
@@ -193,7 +270,7 @@ extension Tracker {
 
 #if targetEnvironment(simulator)
         /// When we're in a simulator environment (iOS Simulator & xcode preview), we do not actually call the tracker - just log it.
-        print("👀 Tracker: \(screen.toString)")
+        logger.info("👀 Tracker: \(screen.toString)")
 #else
         guard let tracker = matomoTracker else { return }
         if let note = note {

--- a/Sources/DesignSystem/Logic/Matomo/TrackerConstants.swift
+++ b/Sources/DesignSystem/Logic/Matomo/TrackerConstants.swift
@@ -1,37 +1,5 @@
 import Foundation
 
-/// `TrackableScreen` is a protocol that represents a screen or view that can be tracked.
-/// Each conforming type must provide a unique `identifier` string used for analytics or logging.
-///
-/// Example:
-/// ```swift
-/// enum MyApp: TrackableScreen {
-///     case home
-///     case settings
-///     case profile(action: TrackerAction)   // Using built-in TrackerAction
-///     case custom(action: CustomAction)     // Using a custom action enum
-///
-///     var identifier: String {
-///         switch self {
-///         case .home: return "home"
-///         case .settings: return "settings"
-///         case .profile(let action): return "profile_\(action.rawValue)"
-///         case .custom(let action): return "custom_\(action.rawValue)"
-///         }
-///     }
-/// }
-///
-/// enum CustomAction: String {
-///     case like, share, comment
-/// }
-///
-/// // Usage:
-/// tracker.trackScreen(MyApp.profile(action: .select))
-/// tracker.trackScreen(MyApp.custom(action: .like))
-/// ```
-public protocol TrackableScreen {
-    var identifier: String { get }
-}
 
 /// TrackerScreen enum is a convenience enum used for type-safe annotation of views that should be tracked
 @available(*, deprecated, message: "Define TrackerScreen constants in your app instead, utilize the TrackableScreen protocol.")

--- a/Sources/DesignSystem/Logic/Matomo/TrackerProtocols.swift
+++ b/Sources/DesignSystem/Logic/Matomo/TrackerProtocols.swift
@@ -1,0 +1,89 @@
+/// `TrackableScreen` is a protocol that represents a screen or view that can be tracked.
+/// Each conforming type must provide a unique `identifier` string used for analytics or logging.
+///
+/// Example:
+/// ```swift
+/// enum MyApp: TrackableScreen {
+///     case home
+///     case settings
+///     case profile(action: TrackerAction)   // Using built-in TrackerAction
+///     case custom(action: CustomAction)     // Using a custom action enum
+///
+///     var identifier: String {
+///         switch self {
+///             case .home: return "home"
+///             case .settings: return "settings"
+///             case .profile(let action): return "profile_\(action.rawValue)"
+///             case .custom(let action): return "custom_\(action.rawValue)"
+///         }
+///     }
+/// }
+///
+/// enum CustomAction: String {
+///     case like, share, comment
+/// }
+///
+/// // Usage:
+/// tracker.trackScreen(MyApp.profile(action: .select))
+/// tracker.trackScreen(MyApp.custom(action: .like))
+/// ```
+public protocol TrackableScreen {
+    var identifier: String { get }
+}
+
+/// `TrackableInteraction` is a protocol that represents a discrete interaction a user performs
+/// *within* a screen — for example adding a symptom, toggling an option, or choosing a value.
+/// Where `TrackableScreen` answers *"where is the user?"*, a `TrackableInteraction` answers
+/// *"what did they do while there?"*.
+///
+/// Each conforming type describes the interaction across up to three fields, which map directly
+/// onto Matomo's event model. The screen the interaction happens on supplies the event category,
+/// so only the interaction-specific fields are defined here:
+/// - `action`: what the user did, e.g. `"add_symptom"` (required) — Matomo `e_a`.
+/// - `name`: the specific value or target of the interaction, e.g. `"nausea"` (optional) — Matomo `e_n`.
+/// - `value`: an optional numeric metric Matomo can sum or average, e.g. a pain level (optional) — Matomo `e_v`.
+///
+/// `name` and `value` default to `nil`, so simple interactions only need to provide `action`.
+///
+/// Example:
+/// ```swift
+/// enum HeadacheInteraction: TrackableInteraction {
+///     case addSymptom(String)    // name carries which symptom
+///     case setPainLevel(Int)     // value carries the number
+///
+///     var action: String {
+///         switch self {
+///             case .addSymptom: return "add_interest"
+///             case .setPainLevel: return "set_pain_level"
+///         }
+///     }
+///
+///     var name: String? {
+///         switch self {
+///             case .addSymptom(let symptom): return symptom
+///             case .setPainLevel: return nil
+///         }
+///     }
+///
+///     var value: Float? {
+///         switch self {
+///             case .setPainLevel(let painLevel): return Float(painLevel)
+///             default: return nil
+///         }
+///     }
+/// }
+///
+/// // Usage: the screen supplies the category, the interaction supplies action/name/value.
+/// tracker.trackEvent(HeadacheInteraction.addSymptom("nausea"), on: MigraineApp.headache(action: .create))
+/// tracker.trackEvent(HeadacheInteraction.setPainLevel(4), on: MigraineApp.headache(action: .edit))
+/// ```
+public protocol TrackableInteraction {
+    var action: String { get }   // e_a — what they did
+    var name: String? { get }    // e_n — the specific value/target
+    var value: Float? { get }    // e_v — optional numeric metric
+}
+
+public extension TrackableInteraction {
+    var name: String? { nil }
+    var value: Float? { nil }
+}


### PR DESCRIPTION
## Summary

Adds real Matomo **event** tracking alongside the existing view tracking, plus an AppVersion custom dimension and consent-change tracking.

- **Event tracking** — new `TrackableInteraction` protocol and `trackEvent(_:on:)` record in-screen interactions as proper Matomo events (`ca=1` + `e_c`/`e_a`/`e_n`/`e_v`). The screen supplies the **category**; the interaction supplies **action / name / value**. This lands in Matomo's Events report instead of polluting Pages.
- **AppVersion dimension** — a permanent (Visit-scope) custom dimension carrying `CFBundleShortVersionString`, set once in the tracker's init from the `MATOMO_APPVERSION_DIMENSION` Info.plist index. Sent with every hit.
- **Consent tracking** — `setOptInSetting` now reports opt-in/opt-out changes. The opt-out event is tracked **and flushed before** `isOptedOut` is set, so it isn't discarded at enqueue time; only genuine, user-initiated changes are reported (the per-launch re-application and first-launch default are excluded).
- **Docs** — clarified that `trackEvent(_:note:)` registers a **view**, not an event (kept intentionally for cases like `delete_medication`); documented the new protocol/method; added a `README.md` covering setup, view tracking, and event tracking.
- **Refactor** — moved the `TrackableScreen` protocol into a new `TrackerProtocols.swift`.

## Consumer action required (per app / site)

The AppVersion dimension only activates once each app adds config:

- Create a **Visit-scope** custom dimension in each site's Matomo backend and note its index.
- Add `MATOMO_APPVERSION_DIMENSION` to the app's `.xcconfig` + `Info.plist` (string, same substitution pattern as `MATOMO_SITE_ID`). Without it, the tracker logs a warning and simply skips the dimension.

## Notes

- No behavioural change to existing `trackScreen` / `trackEvent(_:note:)` view tracking.