### PR TITLE
Add minimumSelectionCount to VGRMultiSelectionList and rebuild the recurrence picker on shared list components

### DIFF
--- a/Sources/DesignSystem/Views/Pickers/RecurrencePicker/VGRRecurrencePickerView.swift
+++ b/Sources/DesignSystem/Views/Pickers/RecurrencePicker/VGRRecurrencePickerView.swift
@@ -29,15 +29,16 @@ import SwiftUI
 /// ```
 public struct VGRRecurrencePickerView: View {
 
+    @ScaledMetric private var iconSize: CGFloat = 22
     @Binding var startDate: Date
     @Binding var selectedFrequency: Int
     @Binding var selectedPeriod: RecurrencePeriod
-    @Binding var selectedWeekdays: [RecurrenceWeekday]?
+    @Binding var selectedWeekdays: Set<RecurrenceWeekday>?
 
     public init(startDate: Binding<Date>,
                 selectedFrequency: Binding<Int>,
                 selectedPeriod: Binding<RecurrencePeriod>,
-                selectedWeekdays: Binding<[RecurrenceWeekday]?>) {
+                selectedWeekdays: Binding<Set<RecurrenceWeekday>?>) {
         self._startDate = startDate
         self._selectedFrequency = selectedFrequency
         self._selectedPeriod = selectedPeriod
@@ -55,6 +56,15 @@ public struct VGRRecurrencePickerView: View {
 
     @State private var selections: [Int] = [0, 0]
 
+    /// Bridges the optional `selectedWeekdays` binding to the non-optional
+    /// selection binding required by `VGRMultiSelectionList`, treating `nil` as empty.
+    private var weekdaySelection: Binding<Set<RecurrenceWeekday>> {
+        Binding(
+            get: { selectedWeekdays ?? [] },
+            set: { selectedWeekdays = $0 }
+        )
+    }
+
     /// selectedIndex only returns a valid value when the user has selected a monthly recurrence pattern
     var selectedIndex: Int? {
         return self.selectedPeriod == .month ? self.startDate.dayInMonth : nil
@@ -65,7 +75,7 @@ public struct VGRRecurrencePickerView: View {
             frequency: self.selectedFrequency,
             period: self.selectedPeriod,
             index: self.selectedIndex,
-            weekdays: self.selectedWeekdays ?? []
+            weekdays: self.selectedWeekdays.map(Array.init) ?? []
         )
         return recurrence.formatString(startDate: startDate)
     }
@@ -88,10 +98,10 @@ public struct VGRRecurrencePickerView: View {
         if weekdays.contains(weekDay) {
             /// Prevent clearing out all weekdays
             if weekdays.count > 1 {
-                weekdays.removeAll { $0 == weekDay }
+                weekdays.remove(weekDay)
             }
         } else {
-            weekdays.append(weekDay)
+            weekdays.insert(weekDay)
         }
 
         selectedWeekdays = weekdays
@@ -117,25 +127,17 @@ public struct VGRRecurrencePickerView: View {
     }
 
     public var body: some View {
-        ScrollView {
-            VStack(spacing: 16) {
-                VStack(spacing: 0) {
-                    HStack(alignment: .top, spacing: 16) {
-                        Text("recurrence.interval".localizedBundle)
-                            .font(.body).fontWeight(.medium)
-                            .foregroundStyle(Color.Neutral.text)
-                        Text(currentSelection)
-                            .multilineTextAlignment(.trailing)
-                            .frame(maxWidth: .infinity, alignment: .trailing)
-                            .font(.body).fontWeight(.regular)
-                            .foregroundStyle(Color.Neutral.text)
-                    }
-                    .foregroundColor(Color.Neutral.text)
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 16)
-
-                    Divider()
-                        .foregroundStyle(Color.Neutral.divider)
+        VGRContainer {
+            VGRSection {
+                VGRList {
+                    VGRListRow(title: "recurrence.interval".localizedBundle,
+                               subtitle: currentSelection,
+                               icon: {
+                        Image(systemName: "repeat")
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: iconSize)
+                    })
 
                     VGRMultiPickerView(data: self.pickerData,
                                        widths: self.widths,
@@ -144,66 +146,20 @@ public struct VGRRecurrencePickerView: View {
                         updateSelection(newVal)
                     }
                 }
-                .frame(maxWidth: .infinity)
-                .background(Color.Elevation.elevation1)
-                .clipShape(RoundedRectangle(cornerRadius: 8))
-                .padding([.top,.leading,.trailing],16)
+            }
 
-                if isWeekPeriod {
-                    VStack(spacing: 16) {
-                        Text("recurrence.weekday.choose".localizedBundle)
-                            .textCase(.none)
-                            .font(.headline)
-                            .foregroundStyle(Color.Neutral.text)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(.leading, 32)
-
-                        VStack(spacing: 0) {
-                            ForEach(RecurrenceWeekday.allCases, id:\.id) { weekday in
-                                Label {
-                                    if selectedWeekdays?.contains(weekday) == true {
-                                        Text("recurrence.weekday.\(weekday.description)".localizedBundle)
-                                            .foregroundStyle(Color.Neutral.text)
-                                            .accessibilityLabel("\("general.selected".localizedBundle), \("recurrence.weekday.\(weekday.description)".localizedBundle)")
-                                    } else {
-                                        Text("recurrence.weekday.\(weekday.description)".localizedBundle)
-                                            .foregroundStyle(Color.Neutral.text)
-                                            .accessibilityLabel("\("general.notselected".localizedBundle), \("recurrence.weekday.\(weekday.description)".localizedBundle)")
-                                    }
-
-                                } icon: {
-                                    if selectedWeekdays?.contains(weekday) == true {
-                                        Image(systemName: "checkmark.circle.fill")
-                                            .foregroundStyle(Color.Primary.action)
-                                    } else {
-                                        Image(systemName: "circle")
-                                            .foregroundStyle(Color.Primary.action)
-                                    }
-                                }
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .padding(16)
-                                .contentShape(Rectangle())
-                                .onTapGesture {
-                                    toggleWeekday(weekday)
-                                }
-
-                                if weekday != .sunday {
-                                    Divider()
-                                        .foregroundStyle(Color.Neutral.divider)
-                                }
-                            }
-                        }
-                        .frame(maxWidth: .infinity)
-                        .background(Color.Elevation.elevation1)
-                        .clipShape(RoundedRectangle(cornerRadius: 8))
-                        .padding([.leading, .trailing, .bottom], 16)
+            if isWeekPeriod {
+                VGRMultiSelectionList(
+                    header: "recurrence.weekday.choose".localizedBundle,
+                    items: RecurrenceWeekday.allCases,
+                    selection: weekdaySelection,
+                    minimumSelectionCount: 1,
+                    warnIfNotSelected: false) { weekday, selected in
+                        VGRCheckRow(title: "recurrence.weekday.\(weekday.description)".localizedBundle,
+                                     isSelected: selected)
                     }
-                    .padding(.top, 16)
-                }
             }
         }
-        .frame(maxWidth: .infinity)
-        .background(Color.Elevation.background)
         .navigationTitle("recurrence.title".localizedBundle)
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {
@@ -216,7 +172,7 @@ public struct VGRRecurrencePickerView: View {
     @Previewable @State var startDate: Date = .now
     @Previewable @State var frequency: Int = 1
     @Previewable @State var period: RecurrencePeriod = .week
-    @Previewable @State var weekdays: [RecurrenceWeekday]? = []
+    @Previewable @State var weekdays: Set<RecurrenceWeekday>? = []
 
     NavigationStack {
         VGRRecurrencePickerView(startDate: $startDate,

--- a/Sources/DesignSystem/Views/Pickers/SelectionList/README.md
+++ b/Sources/DesignSystem/Views/Pickers/SelectionList/README.md
@@ -39,13 +39,16 @@ Lista där användaren kan välja **exakt ett** alternativ. Listan äger bara ur
 ### `VGRMultiSelectionList`
 Lista där användaren kan välja **noll eller fler** alternativ. Listan äger bara urvalstillståndet — radens innehåll byggs av en `row`-closure som tar `(item, isSelected)` och kan returnera vilken vy som helst (ex. `VGRCheckRow`). Valet exponeras som ett `Set` av objekt — samma struktur används för att förvälja rader när vyn visas.
 
-| Parameter            | Typ                          | Default | Beskrivning                                                |
-|----------------------|------------------------------|---------|------------------------------------------------------------|
-| `header`             | `String?`                    | `nil`   | Rubrik för omslutande `VGRSection`                          |
-| `items`              | `[Item]`                     | –       | Alternativen som visas i listan                            |
-| `selection`          | `Binding<Set<Item>>`         | –       | Aktuellt urval. Seed:a för att förvälja rader              |
-| `warnIfNotSelected`  | `Bool`                       | `false` | Visar en varningsram runt listan när urvalet är tomt       |
-| `row`                | `(Item, Bool) -> some View`  | –       | Bygger radens vy givet aktuell `isSelected`-status          |
+Med `minimumSelectionCount` går det att sätta ett golv för hur många objekt som måste vara valda. Klick på en redan vald rad ignoreras när urvalet nått golvet, så användaren kan aldrig avmarkera sig under gränsen. Gränsen bevakar bara avmarkering — den väljer aldrig objekt åt anroparen, så ett urval som seed:as under gränsen lämnas orört tills användaren valt tillräckligt många.
+
+| Parameter               | Typ                          | Default | Beskrivning                                                          |
+|-------------------------|------------------------------|---------|----------------------------------------------------------------------|
+| `header`                | `String?`                    | `nil`   | Rubrik för omslutande `VGRSection`                                    |
+| `items`                 | `[Item]`                     | –       | Alternativen som visas i listan                                      |
+| `selection`             | `Binding<Set<Item>>`         | –       | Aktuellt urval. Seed:a för att förvälja rader                        |
+| `minimumSelectionCount` | `Int`                        | `0`     | Minsta antal valda objekt — förhindrar avmarkering under gränsen     |
+| `warnIfNotSelected`     | `Bool`                       | `false` | Visar en varningsram runt listan tills minsta antalet objekt är valt |
+| `row`                   | `(Item, Bool) -> some View`  | –       | Bygger radens vy givet aktuell `isSelected`-status                    |
 
 ### `VGRSingleSelectionListScreen` / `VGRMultiSelectionListScreen`
 Kompletta skärmar som paketerar respektive lista med standardramverk: navigationstitel, valfri beskrivande rubrik och en `VGRContainer` runt listan. Använd dessa när du behöver det vanliga "välj från en lista"-flödet utan att upprepa layouten i varje anropare. För mer kontroll — komponera listan direkt i din egen vy.
@@ -83,9 +86,10 @@ VGRContainer {
 
 VGRContainer {
     VGRMultiSelectionList(
-        header: "Välj en eller flera faktorer",
+        header: "Välj minst två faktorer",
         items: items,
         selection: $selection,
+        minimumSelectionCount: 2,
         warnIfNotSelected: true
     ) { item, isSelected in
         VGRCheckRow(title: item.name, isSelected: isSelected)

--- a/Sources/DesignSystem/Views/Pickers/SelectionList/VGRMultiSelectionList.swift
+++ b/Sources/DesignSystem/Views/Pickers/SelectionList/VGRMultiSelectionList.swift
@@ -16,6 +16,9 @@ import SwiftUI
 /// pre-selection mechanism — any items present in the set when the view
 /// appears will be shown as selected.
 ///
+/// Pass `minimumSelectionCount` to keep the user from deselecting below a
+/// given number of items.
+///
 /// The rendering is a ``VGRList`` wrapped in a ``VGRSection``; it does not
 /// wrap itself in a `ScrollView` or `NavigationStack`. The caller is
 /// responsible for any surrounding chrome (titles, scroll container, etc.).
@@ -58,6 +61,18 @@ public struct VGRMultiSelectionList<Item: Identifiable & Hashable, Row: View>: V
     /// presenting to pre-select items.
     @Binding public var selection: Set<Item>
 
+    /// The smallest number of items the list lets the user keep selected.
+    /// Defaults to `0` — no lower bound. When set, tapping an already
+    /// selected row is a no-op once the selection has shrunk to this size,
+    /// so the user can never deselect below the limit.
+    ///
+    /// The limit only guards deselection; it never selects items on the
+    /// caller's behalf. A selection seeded below the limit is left as-is
+    /// until the user picks enough items — combine with
+    /// ``warnIfNotSelected`` to flag that state, which then warns while the
+    /// selection is smaller than the limit rather than only when empty.
+    public let minimumSelectionCount: Int
+
     /// Builds the row view for an item. Receives the item and whether it is
     /// currently part of the selection set, so callers can vary content and
     /// styling based on selection state.
@@ -69,7 +84,10 @@ public struct VGRMultiSelectionList<Item: Identifiable & Hashable, Row: View>: V
     ///   - items: The selectable items to display.
     ///   - selection: A binding to the set of selected items. Seed it with
     ///     items to pre-select the corresponding rows.
-    ///   - warnIfNotSelected: Optional flag to show warning if no item is selected.
+    ///   - minimumSelectionCount: The smallest number of items the user is
+    ///     allowed to keep selected. Defaults to `0` — no lower bound.
+    ///   - warnIfNotSelected: Optional flag to show warning if the minimum
+    ///     number of items is not selected.
     ///   - inset: Whether the underlying ``VGRSection`` horizontally insets
     ///     its content. Defaults to `true`. Pass `false` when the list is
     ///     wrapped in a container that already supplies horizontal framing.
@@ -79,6 +97,7 @@ public struct VGRMultiSelectionList<Item: Identifiable & Hashable, Row: View>: V
         header: String? = nil,
         items: [Item],
         selection: Binding<Set<Item>>,
+        minimumSelectionCount: Int = 0,
         warnIfNotSelected: Bool = false,
         inset: Bool = true,
         @ViewBuilder row: @escaping (Item, Bool) -> Row
@@ -88,6 +107,7 @@ public struct VGRMultiSelectionList<Item: Identifiable & Hashable, Row: View>: V
         self.inset = inset
         self.items = items
         self._selection = selection
+        self.minimumSelectionCount = minimumSelectionCount
         self.row = row
     }
 
@@ -105,7 +125,7 @@ public struct VGRMultiSelectionList<Item: Identifiable & Hashable, Row: View>: V
     }
 
     private var showWarning: Bool {
-        return warnIfNotSelected && selection.isEmpty
+        return warnIfNotSelected && selection.count < max(minimumSelectionCount, 1)
     }
 
     public var body: some View {
@@ -116,6 +136,7 @@ public struct VGRMultiSelectionList<Item: Identifiable & Hashable, Row: View>: V
 
     private func toggle(_ item: Item) {
         if selection.contains(item) {
+            guard selection.count > minimumSelectionCount else { return }
             selection.remove(item)
         } else {
             selection.insert(item)
@@ -126,6 +147,7 @@ public struct VGRMultiSelectionList<Item: Identifiable & Hashable, Row: View>: V
 #Preview("VGRMultiSelectionList") {
 
     @Previewable @State var selection: Set<VGRSelectionListItem> = []
+    @Previewable @State var minimumSelection: Set<VGRSelectionListItem> = []
 
     let items = [
         VGRSelectionListItem(name: "Hello"),
@@ -155,6 +177,16 @@ public struct VGRMultiSelectionList<Item: Identifiable & Hashable, Row: View>: V
                 ) { item, isSelected in
                     VGRCheckRow(title: item.name, isSelected: isSelected)
                 }
+            }
+
+            VGRMultiSelectionList(
+                header: "Requires at least two items, and warns until two are picked.",
+                items: items,
+                selection: $minimumSelection,
+                minimumSelectionCount: 2,
+                warnIfNotSelected: true
+            ) { item, isSelected in
+                VGRCheckRow(title: item.name, isSelected: isSelected)
             }
         }
         .navigationTitle("VGRMultiSelectionList")


### PR DESCRIPTION
## VGRMultiSelectionList

Adds an optional `minimumSelectionCount: Int = 0` that sets a floor for how many items must stay selected.

- `toggle` guards removal — once the selection has shrunk to the limit, tapping a selected row is a silent no-op. Selecting is never blocked. This matches `VGRSingleSelectionList`, where a disallowed deselect is also a no-op rather than a disabled row.
- The limit only guards deselection; it never selects items on the caller's behalf. A selection seeded below the limit stays as-is until the user picks enough items.
- `warnIfNotSelected` now warns while `selection.count < max(minimumSelectionCount, 1)` instead of only when empty. At the default of `0` that is byte-for-byte the old behaviour. With a limit set it covers the under-filled state the component can't fix on its own.
- The parameter is inserted before `warnIfNotSelected:` rather than appended, so existing call sites keep a valid argument order.

Not included: the row builder still receives only `(item, isSelected)`, so a locked row can't dim itself — adding a third `canDeselect` parameter would be source-breaking for every caller. `VGRMultiSelectionListScreen` doesn't forward the new parameter, matching that it already forwards neither `warnIfNotSelected` nor `inset`.

## VGRRecurrencePickerView

Replaces the hand-rolled weekday list and card styling with the shared components — `VGRContainer`, `VGRSection`, `VGRList`/`VGRListRow` and `VGRMultiSelectionList` — using `minimumSelectionCount: 1` in place of the local "prevent clearing out all weekdays" guard. The interval row picks up a `repeat` icon and a `@ScaledMetric` icon size.

**Breaking:** `selectedWeekdays` changes from `[RecurrenceWeekday]?` to `Set<RecurrenceWeekday>?` to match the multi-selection list's binding. Consuming apps (dermatology, migraine, epilepsy) need their bound property updated; `Recurrence` still receives an array internally.

## Notes

Not built or run — needs a check in Xcode before merge. No tests exist for the SelectionList components, so none were updated. Folder README parameter table and usage example updated; the preview gained a `minimumSelectionCount: 2` case.