### PR TITLE
Keep Recurrence weekdays sorted and drop dead picker code

### DIFF
--- a/Sources/DesignSystem/Views/Pickers/RecurrencePicker/Recurrence.swift
+++ b/Sources/DesignSystem/Views/Pickers/RecurrencePicker/Recurrence.swift
@@ -13,7 +13,15 @@ public struct Recurrence: Codable, Equatable, Hashable, Sendable {
 
     /// weekdays is used to control which weekdays are affected
     /// this is only applicable when period is set to _week_
-    public var weekdays: [RecurrenceWeekday]?
+    ///
+    /// The list is kept sorted no matter which order it is assigned in, so
+    /// that two recurrences covering the same weekdays always compare equal,
+    /// hash alike and encode to identical JSON. Callers building the list
+    /// from an unordered collection — a `Set` from ``VGRMultiSelectionList``,
+    /// for instance — therefore do not have to sort it themselves.
+    public var weekdays: [RecurrenceWeekday]? {
+        didSet { weekdays = weekdays?.sorted() }
+    }
 
     enum CodingKeys: String, CodingKey {
         case frequency = "frequency"
@@ -26,7 +34,22 @@ public struct Recurrence: Codable, Equatable, Hashable, Sendable {
         self.frequency = frequency
         self.period = period
         self.index = index
-        self.weekdays = weekdays
+        /// Property observers do not run during initialization, so the sort
+        /// is repeated here to keep every entry point normalized
+        self.weekdays = weekdays?.sorted()
+    }
+
+    /// Decoding is routed through the memberwise initializer so that weekdays
+    /// persisted before normalization are sorted on the way in, and compare
+    /// equal to a freshly built recurrence covering the same days.
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            frequency: try container.decode(Int.self, forKey: .frequency),
+            period: try container.decode(RecurrencePeriod.self, forKey: .period),
+            index: try container.decodeIfPresent(Int.self, forKey: .index),
+            weekdays: try container.decodeIfPresent([RecurrenceWeekday].self, forKey: .weekdays)
+        )
     }
 
     /// decodeFromString takes a string containing a JSON object and decodes it into a `Recurrence` struct.

--- a/Sources/DesignSystem/Views/Pickers/RecurrencePicker/VGRRecurrencePickerView.swift
+++ b/Sources/DesignSystem/Views/Pickers/RecurrencePicker/VGRRecurrencePickerView.swift
@@ -75,7 +75,7 @@ public struct VGRRecurrencePickerView: View {
             frequency: self.selectedFrequency,
             period: self.selectedPeriod,
             index: self.selectedIndex,
-            weekdays: self.selectedWeekdays.map(Array.init) ?? []
+            weekdays: self.selectedWeekdays?.sorted() ?? []
         )
         return recurrence.formatString(startDate: startDate)
     }
@@ -86,25 +86,6 @@ public struct VGRRecurrencePickerView: View {
 
     var isMonthPeriod: Bool {
         return self.selections[1] == RecurrencePeriod.month.rawValue
-    }
-
-    func toggleWeekday(_ weekDay: RecurrenceWeekday) {
-        guard var weekdays = selectedWeekdays else {
-            /// If nil, initialize with the tapped weekday
-            selectedWeekdays = [weekDay]
-            return
-        }
-
-        if weekdays.contains(weekDay) {
-            /// Prevent clearing out all weekdays
-            if weekdays.count > 1 {
-                weekdays.remove(weekDay)
-            }
-        } else {
-            weekdays.insert(weekDay)
-        }
-
-        selectedWeekdays = weekdays
     }
 
     func setSelections() {

--- a/Tests/designsystem-Tests/RecurrenceTests.swift
+++ b/Tests/designsystem-Tests/RecurrenceTests.swift
@@ -804,4 +804,74 @@ final class RecurrenceTests: XCTestCase {
         // Should include Jan 1, 2, 3 despite the specific times
         XCTAssertEqual(dates.count, 3, "Should normalize to full days")
     }
+
+    // MARK: - Weekday Normalization Tests
+
+    func testWeekdaysSortedOnInit() throws {
+        let recurrence = Recurrence(frequency: 1, period: .week, weekdays: [.friday, .sunday, .monday])
+
+        XCTAssertEqual(recurrence.weekdays, [.monday, .friday, .sunday],
+                       "Weekdays should be sorted on init, with Sunday last")
+    }
+
+    func testWeekdaysSortedOnMutation() throws {
+        var recurrence = Recurrence(frequency: 1, period: .week, weekdays: [.monday])
+        recurrence.weekdays = [.saturday, .tuesday]
+
+        XCTAssertEqual(recurrence.weekdays, [.tuesday, .saturday],
+                       "Weekdays should be sorted when assigned after init")
+    }
+
+    func testWeekdaysSortedOnDecoding() throws {
+        let json = """
+        {
+            "frequency": 1,
+            "period": 1,
+            "weekdays": [6, 1, 2]
+        }
+        """
+
+        let recurrence = try JSONDecoder().decode(Recurrence.self, from: Data(json.utf8))
+
+        XCTAssertEqual(recurrence.weekdays, [.monday, .friday, .sunday],
+                       "Weekdays persisted in arbitrary order should be sorted on decode")
+    }
+
+    func testWeekdaysFromUnorderedSetAreEqualRegardlessOfOrder() throws {
+        /// A `Set` has no defined iteration order, so a recurrence built from
+        /// one must not depend on the order the elements happen to come out in.
+        let selection: Set<RecurrenceWeekday> = [.monday, .wednesday, .friday]
+
+        let r1 = Recurrence(frequency: 1, period: .week, weekdays: Array(selection))
+        let r2 = Recurrence(frequency: 1, period: .week, weekdays: [.friday, .monday, .wednesday])
+
+        XCTAssertEqual(r1, r2, "Same weekdays in a different order should be equal")
+        XCTAssertEqual(r1.hashValue, r2.hashValue, "Equal recurrences should hash alike")
+    }
+
+    func testEncodingIsStableAcrossWeekdayOrder() throws {
+        let r1 = Recurrence(frequency: 1, period: .week, weekdays: [.wednesday, .monday])
+        let r2 = Recurrence(frequency: 1, period: .week, weekdays: [.monday, .wednesday])
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+
+        XCTAssertEqual(try encoder.encode(r1), try encoder.encode(r2),
+                       "Weekday order should not change the persisted JSON")
+    }
+
+    func testFormatStringUnaffectedByWeekdayOrder() throws {
+        let r1 = Recurrence(frequency: 1, period: .week, weekdays: [.friday, .monday])
+        let r2 = Recurrence(frequency: 1, period: .week, weekdays: [.monday, .friday])
+
+        XCTAssertEqual(r1.formatString(), r2.formatString(),
+                       "Description should not depend on weekday order")
+    }
+
+    func testNilWeekdaysStayNil() throws {
+        var recurrence = Recurrence(frequency: 1, period: .week, weekdays: [.monday])
+        recurrence.weekdays = nil
+
+        XCTAssertNil(recurrence.weekdays, "Sorting should not turn nil into an empty array")
+    }
 }


### PR DESCRIPTION
Follow-up to #174. Closes the ordering hazard that the `[RecurrenceWeekday]?` → `Set<RecurrenceWeekday>?` change opened up, without touching the public binding again.

## The problem

`Recurrence.weekdays` is still a `[RecurrenceWeekday]?` that encodes as a JSON array, and `Recurrence.==` compares it order-sensitively. `Array(someSet)` has no defined order, so a consumer doing `Recurrence(weekdays: Array(selection))` could produce logically identical recurrences that compare unequal, hash differently, and persist to different JSON between runs.

Nothing inside the design system was affected — `formatString` sorts before rendering and `getRecurringDates` matches with `.contains` — so the exposure was entirely in what the consuming apps store and compare.

## The fix

`weekdays` is now sorted at every entry point:

- the memberwise init (property observers don't run during initialization, so the sort is explicit there)
- a `init(from:)` that routes decoding through the memberwise init, which also normalizes weekdays persisted before this change
- a `didSet` for assignment and in-place mutation after init

`RecurrenceWeekday` is already `Comparable`, with the custom `<` that sorts Sunday last, so the order is the one `formatString` was already using. Callers can hand over an unordered collection and stop thinking about it.

`VGRRecurrencePickerView` builds its array with `sorted()` rather than `Array.init`, and loses `toggleWeekday` — dead since the weekday list moved to `VGRMultiSelectionList` in #174. It was internal, so this is not an API change.

## Tests

Seven cases added to `RecurrenceTests`: sorting on init, on mutation and on decode; equality and hashing from a `Set`-built array; stable encoding across weekday order; `formatString` independence; and `nil` staying `nil` rather than becoming `[]`. Existing tests all use pre-sorted weekday arrays, so none needed changing.

Not built or run — needs a check in Xcode before merge.