### PR TITLE
Build VGRNavRow destinations lazily and deprecate VGRTableRowNavigationLink

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Komponenter bör ha tydliga `#Preview`-block för att enkelt kunna testas i Xcod
 - `VGRDoneButton` - Klar-knapp med iOS 26-stöd och fallback
 - `VGRStepper` - Steg-kontroll för att öka/minska värden
 - `VGRToggle` - Anpassad toggle-switch
-- `VGRTableRowNavigationLink` - Navigationslänk för tabellrader
+- `VGRTableRowNavigationLink` - Navigationslänk för tabellrader (**deprecated** — använd `VGRNavRow`)
 
 ### Kort & Utrop
 - `VGRCallout` - Informations-/varningsruta med valfria ikoner och illustrationer

--- a/Sources/DesignSystem/Views/Buttons/TableRowNavigationLink/VGRTableRowNavigationLink.swift
+++ b/Sources/DesignSystem/Views/Buttons/TableRowNavigationLink/VGRTableRowNavigationLink.swift
@@ -16,6 +16,12 @@ import SwiftUI
 /// ```swift
 /// TableRowNavigationLink(destination: SettingsView(), title: "Inställningar", subtitle: "Hantera dina preferenser", iconName: "gear")
 /// ```
+///
+/// > Deprecated: Använd ``VGRNavRow`` i en ``VGRList`` istället. Ersättaren tar
+/// > ikon och accessory som view builders istället för `iconName`/`details`,
+/// > och bygger sin destination först när raden trycks — den här komponenten
+/// > konstruerar varje destination direkt, även de som aldrig visas.
+@available(*, deprecated, message: "Use VGRNavRow inside a VGRList instead.")
 public struct VGRTableRowNavigationLink<Destination: View>: View {
     
     // MARK: - Properties
@@ -128,34 +134,35 @@ public struct VGRTableRowNavigationLink<Destination: View>: View {
     }
 }
 
-#Preview("SettingsListRow") {
-    
-    NavigationStack {
-        ScrollView {
-            VStack (alignment: .leading) {
+//MARK: This component is deprecated - Preview is commented out to reduce number of unescessary Xcode-warnings in the project.
 
-                VGRTableRowNavigationLink(destination: EmptyView(), title: "Anfallshantering", iconName: "settings_attack")
-
-                VGRDivider()
-                
-                VGRTableRowNavigationLink(destination: EmptyView(), title: "Användarvillkor")
-
-                VGRDivider()
-
-                VGRTableRowNavigationLink(destination: EmptyView(), title: "Ge oss Feedback")
-
-                VGRDivider()
-
-                VGRTableRowNavigationLink(destination: EmptyView(), title: "Personuppgiftspolicy")
-
-                VGRDivider()
-
-                VGRTableRowNavigationLink(destination: EmptyView(), title: "Tillgänglighetsredogörelse")
-
-                VGRDivider()
-
-                VGRTableRowNavigationLink(destination: EmptyView(), title: "Tillgänglighetsredogörelse", subtitle: "Hej", details: "Test")
-            }
-        }
-    }
-}
+//#Preview {
+//    NavigationStack {
+//        ScrollView {
+//            VStack (alignment: .leading) {
+//
+//                VGRTableRowNavigationLink(destination: EmptyView(), title: "Anfallshantering", iconName: "settings_attack")
+//
+//                VGRDivider()
+//
+//                VGRTableRowNavigationLink(destination: EmptyView(), title: "Användarvillkor")
+//
+//                VGRDivider()
+//
+//                VGRTableRowNavigationLink(destination: EmptyView(), title: "Ge oss Feedback")
+//
+//                VGRDivider()
+//
+//                VGRTableRowNavigationLink(destination: EmptyView(), title: "Personuppgiftspolicy")
+//
+//                VGRDivider()
+//
+//                VGRTableRowNavigationLink(destination: EmptyView(), title: "Tillgänglighetsredogörelse")
+//
+//                VGRDivider()
+//
+//                VGRTableRowNavigationLink(destination: EmptyView(), title: "Tillgänglighetsredogörelse", subtitle: "Hej", details: "Test")
+//            }
+//        }
+//    }
+//}

--- a/Sources/DesignSystem/Views/Design/Divider/VGRDivider.swift
+++ b/Sources/DesignSystem/Views/Design/Divider/VGRDivider.swift
@@ -17,30 +17,31 @@ public struct VGRDivider: View {
             .background(Color.Neutral.divider)
     }
 }
+
 #Preview {
-    return NavigationStack {
-        ScrollView {
-            VStack (alignment: .leading) {
+    NavigationStack {
+        VGRContainer {
 
-                VGRTableRowNavigationLink(destination: EmptyView(), title: "Anfallshantering", iconName: "settings_attack")
+            VGRSection {
 
-                VGRTableRowNavigationLink(destination: EmptyView(), title: "Användarvillkor")
+                /// VGRList skjuter in VGRDivider mellan varje element
+                VGRList {
 
-                VGRDivider()
+                    VGRNavRow(title: "Anfallshantering",
+                              icon: { Image(systemName: "gearshape") }) { EmptyView() }
 
-                VGRTableRowNavigationLink(destination: EmptyView(), title: "Ge oss Feedback")
+                    VGRNavRow(title: "Användarvillkor") { EmptyView() }
 
-                VGRDivider()
+                    VGRNavRow(title: "Ge oss Feedback") { EmptyView() }
 
-                VGRTableRowNavigationLink(destination: EmptyView(), title: "Personuppgiftspolicy")
+                    VGRNavRow(title: "Personuppgiftspolicy") { EmptyView() }
 
-                VGRDivider()
+                    VGRNavRow(title: "Tillgänglighetsredogörelse") { Text("Karl Anka") }
 
-                VGRTableRowNavigationLink(destination: EmptyView(), title: "Tillgänglighetsredogörelse")
-
-                VGRDivider()
-
-                VGRTableRowNavigationLink(destination: EmptyView(), title: "Tillgänglighetsredogörelse", subtitle: "Hej", details: "Test")
+                    VGRNavRow(title: "Tillgänglighetsredogörelse",
+                              subtitle: "Hej",
+                              accessory: { Text("Test") }) { EmptyView() }
+                }
             }
         }
     }

--- a/Sources/DesignSystem/Views/Design/Divider/VGRTableRowDivider.swift
+++ b/Sources/DesignSystem/Views/Design/Divider/VGRTableRowDivider.swift
@@ -18,31 +18,37 @@ public struct VGRTableRowDivider: View {
             .background(Color.Neutral.divider)
     }
 }
-#Preview {
-    return NavigationStack {
-        ScrollView {
-            VStack (alignment: .leading) {
-                
-                VGRTableRowNavigationLink(destination: EmptyView(), title: "Anfallshantering", iconName: "settings_attack")
-                
-                VGRTableRowNavigationLink(destination: EmptyView(), title: "Användarvillkor")
 
-                VGRDivider()
+//MARK: This component is deprecated - Preview is commented out to reduce number of unescessary Xcode-warnings in the project.
 
-                VGRTableRowNavigationLink(destination: EmptyView(), title: "Ge oss Feedback")
-                
-                VGRDivider()
-
-                VGRTableRowNavigationLink(destination: EmptyView(), title: "Personuppgiftspolicy")
-                
-                VGRDivider()
-
-                VGRTableRowNavigationLink(destination: EmptyView(), title: "Tillgänglighetsredogörelse")
-                
-                VGRDivider()
-
-                VGRTableRowNavigationLink(destination: EmptyView(), title: "Tillgänglighetsredogörelse", subtitle: "Hej", details: "Test")
-            }
-        }
-    }
-}
+//#Preview {
+//    return NavigationStack {
+//        ScrollView {
+//            VStack (alignment: .leading) {
+//                
+//                VGRNavRow(title: "Anfallshantering",
+//                          icon: { Image(systemName: "gearshape") }) { EmptyView() }
+//
+//                VGRNavRow(title: "Användarvillkor") { EmptyView() }
+//
+//                VGRDivider()
+//
+//                VGRNavRow(title: "Ge oss Feedback") { EmptyView() }
+//
+//                VGRDivider()
+//
+//                VGRNavRow(title: "Personuppgiftspolicy") { EmptyView() }
+//
+//                VGRDivider()
+//
+//                VGRNavRow(title: "Tillgänglighetsredogörelse") { EmptyView() }
+//
+//                VGRDivider()
+//
+//                VGRNavRow(title: "Tillgänglighetsredogörelse",
+//                          subtitle: "Hej",
+//                          accessory: { Text("Test") }) { EmptyView() }
+//            }
+//        }
+//    }
+//}

--- a/Sources/DesignSystem/Views/Lists/README.md
+++ b/Sources/DesignSystem/Views/Lists/README.md
@@ -52,6 +52,16 @@ Alla rader utom `VGRNoteRow` är avsedda att placeras inuti en `VGRList`. `VGRCh
 
 ---
 
+## 🧰 Uppskjuten destination i `VGRNavRow`
+
+`NavigationLink` tar sin destination som en *non-escaping* closure och bygger den direkt. En lista med `VGRNavRow` skulle därför konstruera varje destination redan när listan renderas — och bygga om dem vid varje omritning — trots att ingen av dem visas.
+
+`VGRNavRow` lagrar därför sin destination som en closure och anropar den först via en privat hjälpvy vars `body` bygger destinationen. Det flyttar bygget från konstruktionstid till renderingstid, så destinationen skapas först när raden trycks. Anropare får beteendet utan att göra något — API:t är oförändrat.
+
+Observera att endast *konstruktionen* skjuts upp. Destinationens `body`, `onAppear` och `task` skjuts redan upp av SwiftUI tills vyn visas. Bygger du en egen `NavigationLink` med en dyr destination behöver du samma mönster på anropssidan.
+
+---
+
 ## 🧪 Användning
 
 ```swift

--- a/Sources/DesignSystem/Views/Lists/VGRNavRow.swift
+++ b/Sources/DesignSystem/Views/Lists/VGRNavRow.swift
@@ -14,6 +14,13 @@ import SwiftUI
 /// the trailing closure always binds to the navigation destination
 /// regardless of which other slots are filled.
 ///
+/// The destination builder is stored rather than called, and handed to the
+/// `NavigationLink` behind a deferring wrapper, so the destination is only
+/// constructed when the row is actually tapped. Without that indirection
+/// every destination in a list would be built up front — and rebuilt on
+/// every re-render — because `NavigationLink` takes its destination as a
+/// non-escaping closure and evaluates it immediately.
+///
 /// ### Usage
 /// ```swift
 /// VGRNavRow(title: "Title") {
@@ -33,6 +40,18 @@ import SwiftUI
 /// ```
 public struct VGRNavRow<Icon: View, Accessory: View, Destination: View>: View {
 
+    /// Defers building the destination until it is rendered.
+    ///
+    /// A view's `init` runs as soon as the struct is created, while its
+    /// `body` runs only when SwiftUI needs to draw it. `NavigationLink` takes
+    /// its destination as a non-escaping closure and so always builds
+    /// something immediately — this keeps that something trivial, and leaves
+    /// the real destination to be built on push.
+    private struct LazyDestination: View {
+        let build: () -> Destination
+        var body: Destination { build() }
+    }
+
     @ScaledMetric private var chevronSize: CGFloat = 25
 
     /// The primary text shown on the row.
@@ -43,7 +62,10 @@ public struct VGRNavRow<Icon: View, Accessory: View, Destination: View>: View {
 
     let icon: Icon
     let accessory: Accessory
-    let destination: Destination
+
+    /// Held as a closure rather than a built view so that the destination is
+    /// not constructed until the row is tapped.
+    let destination: () -> Destination
 
     /// Creates a nav row with both an icon and an accessory.
     /// - Parameters:
@@ -57,12 +79,12 @@ public struct VGRNavRow<Icon: View, Accessory: View, Destination: View>: View {
                 subtitle: String? = nil,
                 @ViewBuilder icon: () -> Icon,
                 @ViewBuilder accessory: () -> Accessory,
-                @ViewBuilder destination: () -> Destination) {
+                @ViewBuilder destination: @escaping () -> Destination) {
         self.title = title
         self.subtitle = subtitle
         self.icon = icon()
         self.accessory = accessory()
-        self.destination = destination()
+        self.destination = destination
     }
 
     /// Creates a nav row without an icon.
@@ -74,12 +96,12 @@ public struct VGRNavRow<Icon: View, Accessory: View, Destination: View>: View {
     public init(title: String,
                 subtitle: String? = nil,
                 @ViewBuilder accessory: () -> Accessory,
-                @ViewBuilder destination: () -> Destination) where Icon == EmptyView {
+                @ViewBuilder destination: @escaping () -> Destination) where Icon == EmptyView {
         self.title = title
         self.subtitle = subtitle
         self.icon = EmptyView()
         self.accessory = accessory()
-        self.destination = destination()
+        self.destination = destination
     }
 
     /// Creates a nav row without an accessory.
@@ -91,12 +113,12 @@ public struct VGRNavRow<Icon: View, Accessory: View, Destination: View>: View {
     public init(title: String,
                 subtitle: String? = nil,
                 @ViewBuilder icon: () -> Icon,
-                @ViewBuilder destination: () -> Destination) where Accessory == EmptyView {
+                @ViewBuilder destination: @escaping () -> Destination) where Accessory == EmptyView {
         self.title = title
         self.subtitle = subtitle
         self.icon = icon()
         self.accessory = EmptyView()
-        self.destination = destination()
+        self.destination = destination
     }
 
     /// Creates a nav row with neither an icon nor an accessory — the
@@ -107,17 +129,17 @@ public struct VGRNavRow<Icon: View, Accessory: View, Destination: View>: View {
     ///   - destination: A view builder that produces the navigation destination.
     public init(title: String,
                 subtitle: String? = nil,
-                @ViewBuilder destination: () -> Destination) where Icon == EmptyView, Accessory == EmptyView {
+                @ViewBuilder destination: @escaping () -> Destination) where Icon == EmptyView, Accessory == EmptyView {
         self.title = title
         self.subtitle = subtitle
         self.icon = EmptyView()
         self.accessory = EmptyView()
-        self.destination = destination()
+        self.destination = destination
     }
 
     public var body: some View {
         NavigationLink {
-            destination
+            LazyDestination(build: destination)
         } label: {
             VGRListRow(title: title,
                        subtitle: subtitle,

--- a/Tests/designsystem-Tests/VGRNavRowLazinessTests.swift
+++ b/Tests/designsystem-Tests/VGRNavRowLazinessTests.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+import XCTest
+@testable import DesignSystem
+
+@MainActor
+final class VGRNavRowLazinessTests: XCTestCase {
+
+    @MainActor
+    private final class Probe {
+        static var initCount = 0
+    }
+
+    @MainActor
+    private struct ProbeDestination: View {
+        init() { Probe.initCount += 1 }
+        var body: some View { Text("destination") }
+    }
+
+    func testDestinationIsNotBuiltWhenRowIsCreated() {
+        Probe.initCount = 0
+
+        _ = VGRNavRow(title: "Row") { ProbeDestination() }
+
+        XCTAssertEqual(Probe.initCount, 0,
+                       "Destination must not be constructed when the row is created")
+    }
+
+    func testDestinationIsNotBuiltWhenRowBodyIsEvaluated() {
+        Probe.initCount = 0
+
+        let row = VGRNavRow(title: "Row") { ProbeDestination() }
+        _ = row.body
+
+        XCTAssertEqual(Probe.initCount, 0,
+                       "Destination must not be constructed when the row renders")
+    }
+
+    /// Positive control. Without it the two assertions above would also pass
+    /// if the probe simply never counted anything.
+    func testProbeCountsItsOwnConstruction() {
+        Probe.initCount = 0
+
+        _ = ProbeDestination()
+
+        XCTAssertEqual(Probe.initCount, 1, "Probe should count each construction")
+    }
+}


### PR DESCRIPTION
## The bug

Destination views passed to `VGRNavRow` were being constructed for every row as soon as the list rendered, without anyone navigating to them.

Two things combined to cause it. `VGRNavRow` called its destination builder in `init` and stored the finished view, so the destination was built when the *row* was built. And `VGRList` lays rows out in a plain, non-lazy `VStack`, so every row in the card is built immediately.

The cost was worse than once per screen: any state change that re-evaluated the parent body reconstructed every destination again. Anything doing real work in `init` — creating a view model, reading from storage — paid that cost repeatedly, for views the user never opened.

## The fix

`VGRNavRow` now stores the destination builder rather than calling it, and hands it to the `NavigationLink` behind a private `LazyDestination` wrapper whose `body` performs the build.

The wrapper is necessary because `NavigationLink` takes its destination as a **non-escaping** closure (confirmed against the SDK interface) and so always builds something immediately. We can't make `NavigationLink` lazy — we make the thing it eagerly builds trivial. `LazyDestination` costs one stored closure; the real destination is built when SwiftUI renders it, on push.

It is nested inside `VGRNavRow` and picks up the outer `Destination` generic, so this adds no public API. The alternative considered was `Button` + `.navigationDestination(item:)`, whose closure *is* `@escaping` and so is lazy without a wrapper — rejected because a per-row destination modifier can be torn down in a lazy container, and it gives up `NavigationPath` participation and split-view behaviour.

**No call-site changes.** The generic signature is unchanged and `@ViewBuilder` on the parameter means the trailing closure is written exactly as before.

## Tests

`VGRNavRowLazinessTests` counts how many times a probe destination is constructed:

- not constructed when the row is created
- not constructed when the row's `body` is evaluated — the one that proves the non-escaping closure doesn't defeat the wrapper
- a probe control asserting the counter actually increments, so the two above can't pass for the wrong reason

The first two were written against the old code and observed failing before the fix was applied.

## Deprecation

`VGRTableRowNavigationLink` is marked deprecated pointing at `VGRNavRow`. It has the same eager-destination pattern, but takes an already-built `destination` as a plain parameter, so fixing it would mean a signature change on a component that is on its way out.

`message:` is used rather than `renamed:` because the APIs diverge — the replacement takes icon and accessory as view builders instead of `iconName`/`details` strings — so a rename fix-it would produce code that doesn't compile.

The two divider previews used the component as filler and would have started emitting warnings, so they move to `VGRNavRow`; `VGRDivider`'s preview now shows the dividers `VGRList` inserts between rows. The previews belonging to the two deprecated components are commented out to keep the warning count down.

## Notes

Tests were run and pass. Consuming apps will see new deprecation warnings wherever `VGRTableRowNavigationLink` is used — that's the intent, and nothing breaks.