### PR TITLE
Print tracker diagnostics in simulator builds instead of using Logger

### DIFF
--- a/Sources/DesignSystem/Logic/Matomo/Tracker.swift
+++ b/Sources/DesignSystem/Logic/Matomo/Tracker.swift
@@ -18,7 +18,11 @@ public class Tracker {
         let appVersion = Bundle.main.appVersionLong
 
 #if targetEnvironment(simulator)
-        logger.info("📱 Tracker is running in simulated environment")
+        /// Surface the configuration the tracker *would* have used. These values are never validated here,
+        /// so an empty one is only discovered on device, where it trips the `fatalError` below.
+        let siteIdDescription = matomoSiteId.isEmpty ? "⚠️ missing" : matomoSiteId
+        let urlDescription = matomoURL.isEmpty ? "⚠️ missing" : matomoURL
+        print("📱 Tracker is running in simulated environment — MATOMO_SITE_ID: \(siteIdDescription), MATOMO_URL: \(urlDescription)")
         matomoTracker = nil
 #else
         if matomoURL.isEmpty || matomoSiteId.isEmpty {
@@ -60,12 +64,19 @@ public class Tracker {
         // TODO: (ea) - Find a way to include voiceOver state in tracking
         // let isVoiceOverActive = UIAccessibility.isVoiceOverRunning
 
-        guard getOptInSetting() else { return }
+        guard getOptInSetting() else {
+#if targetEnvironment(simulator)
+            /// Report the suppression so a silent console distinguishes "the user is opted out" from "the call never happened".
+            let noteSuffix = note.map { ", 🗒️ \"\($0)\"" } ?? ""
+            print("🚫 Tracker: opted out, skipping \(screen.identifier)\(noteSuffix)")
+#endif
+            return
+        }
 
 #if targetEnvironment(simulator)
         /// When we're in a simulator environment (iOS Simulator & xcode preview), we do not actually call the tracker - just log it.
         let noteSuffix = note.map { ", 🗒️ \"\($0)\"" } ?? ""
-        logger.info("👀 Tracker: \(screen.identifier)\(noteSuffix)")
+        print("👀 Tracker: \(screen.identifier)\(noteSuffix)")
 #else
         guard let tracker = matomoTracker else { return }
         
@@ -91,13 +102,21 @@ public class Tracker {
     ///   - screen: The screen the interaction happened on, conforming to `TrackableScreen`. Its
     ///     `identifier` is used as the event category (`e_c`).
     public func trackEvent(_ interaction: TrackableInteraction, on screen: TrackableScreen) {
-        guard getOptInSetting() else { return }
+        guard getOptInSetting() else {
+#if targetEnvironment(simulator)
+            /// Report the suppression so a silent console distinguishes "the user is opted out" from "the call never happened".
+            let n = interaction.name.map { " / \($0)" } ?? ""
+            let v = interaction.value.map { " = \($0)" } ?? ""
+            print("🚫 Event: opted out, skipping \(screen.identifier) / \(interaction.action)\(n)\(v)")
+#endif
+            return
+        }
 
 #if targetEnvironment(simulator)
         /// When we're in a simulator environment (iOS Simulator & xcode preview), we do not actually call the tracker - just log it.
         let n = interaction.name.map { " / \($0)" } ?? ""
         let v = interaction.value.map { " = \($0)" } ?? ""
-        logger.info("⚡️ Event: \(screen.identifier) / \(interaction.action)\(n)\(v)")
+        print("⚡️ Event: \(screen.identifier) / \(interaction.action)\(n)\(v)")
 #else
         guard let tracker = matomoTracker else { return }
         tracker.track(
@@ -234,7 +253,9 @@ public class Tracker {
         UserDefaults.standard.set(isOptedIn, forKey: personalDataAgreementAccepted)
 
         guard let tracker = matomoTracker else {
-            logger.info("👀 Tracker is disabled: Opt-in setting should be set to '\(isOptedIn)'")
+#if targetEnvironment(simulator)
+            print("👀 Tracker is disabled: Opt-in setting should be set to '\(isOptedIn)'")
+#endif
             return
         }
 
@@ -270,7 +291,7 @@ extension Tracker {
 
 #if targetEnvironment(simulator)
         /// When we're in a simulator environment (iOS Simulator & xcode preview), we do not actually call the tracker - just log it.
-        logger.info("👀 Tracker: \(screen.toString)")
+        print("👀 Tracker: \(screen.toString)")
 #else
         guard let tracker = matomoTracker else { return }
         if let note = note {


### PR DESCRIPTION
## Problem

Calling `.track(screen)` in a SwiftUI preview produced no console output at all. The simulator branch of `Tracker` logged via `Logger` (OSLog), which writes to the unified logging system rather than stdout. Xcode only mirrors that into its console when it is attached to the process as a debugger, and the preview host process is not. The messages were going to the unified log and nowhere visible.

`print()` is piped into Xcode's console for both previews and simulator runs, so the simulator-only diagnostics now use that. The device path is untouched and still uses `Logger`.

## Changes

- Simulator-only `logger.info` calls replaced with `print` in `init`, `trackScreen`, `trackEvent`, and the deprecated `trackScreen(_: TrackerScreen)`.
- `trackScreen` and `trackEvent` now report opted-out calls, so a silent console distinguishes "the user is opted out" from "the call never ran". This was the second candidate cause of the original silence: previews share the app's UserDefaults container, so an earlier opt-out in that simulator carries into the preview and makes every call return at the guard.
- The init message surfaces `MATOMO_SITE_ID` and `MATOMO_URL`, rendering empty values as `⚠️ missing`. The simulator branch never validates these, so a missing `Info.plist` key was previously only discovered on device, where it trips `fatalError("invalid configuration for analytics")`.
- The disabled-tracker message in `setOptInSetting` is now wrapped in `#if targetEnvironment(simulator)`. Nothing is lost on device: `matomoTracker` can only be nil in the simulator, since `init` either assigns it or calls `fatalError`.

## Notes

- Every new `print` sits inside `#if targetEnvironment(simulator)`, so none of it is compiled into device builds — no stdout writes and no unredacted strings in release.
- `logger` is now only used by the `logger.warning` on the device path. It is unused in simulator builds, which Swift does not warn about for stored properties.
- Sample simulator output:
  ```
  📱 Tracker is running in simulated environment — MATOMO_SITE_ID: 42, MATOMO_URL: https://…/matomo.php
  👀 Tracker is disabled: Opt-in setting should be set to 'true'
  👀 Tracker: dashboard
  🚫 Tracker: opted out, skipping settings
  ```

## Testing

Not built or run on my side — worth a compile against a device destination as well as the simulator, since that is where the `#if` branches flip.