### PR TITLE
Make the card image optional in VGRCardView

### DIFF
--- a/Sources/DesignSystem/Views/Cards/Card/VGRCardButton.swift
+++ b/Sources/DesignSystem/Views/Cards/Card/VGRCardButton.swift
@@ -13,14 +13,14 @@ public struct VGRCardButton: View {
     ///   - sizeClass: The size class for the card (small, medium, or large).
     ///   - title: The main title displayed on the card.
     ///   - subtitle: The subtitle or read time displayed below the title, defaults to empty.
-    ///   - imageUrl: The URL or name of the image to display.
+    ///   - imageUrl: The URL or name of the image to display. When empty (the default), no image is shown.
     ///   - isNew: Indicates whether to show the "new" badge. Defaults to `false`.
     ///   - onPressed: Closure called when the button is pressed.
     public init(
         sizeClass: VGRCardSizeClass,
         title: String,
         subtitle: String = "",
-        imageUrl: String,
+        imageUrl: String = "",
         isNew: Bool = false,
         onPressed: @escaping () -> Void
     ) {
@@ -90,6 +90,22 @@ public struct VGRCardButton: View {
                     isNew: false
                 ) {
                     print("I pressed article Treatment Options")
+                }
+
+                VGRCardButton(
+                    sizeClass: .small,
+                    title: "Living with Psoriasis",
+                    isNew: false
+                ) {
+                    print("I pressed article Living with Psoriasis")
+                }
+
+                VGRCardButton(
+                    sizeClass: .small,
+                    title: "Living la vida loca",
+                    isNew: true
+                ) {
+                    print("I pressed article Living with Psoriasis")
                 }
 
                 VGRCardButton(

--- a/Sources/DesignSystem/Views/Cards/Card/VGRCardView.swift
+++ b/Sources/DesignSystem/Views/Cards/Card/VGRCardView.swift
@@ -57,7 +57,7 @@ public struct VGRCardView: View {
     ///   - sizeClass: The size class for the card (small, medium, or large).
     ///   - title: The main title displayed on the card.
     ///   - subtitle: The subtitle or read time displayed below the title, defaults to empty.
-    ///   - imageUrl: The URL or name of the image to display.
+    ///   - imageUrl: The URL or name of the image to display. When empty (the default), no image is shown.
     ///   - isNew: Indicates whether to show the "new" badge. Defaults to `false`.
     public init(
         sizeClass: VGRCardSizeClass,
@@ -83,8 +83,13 @@ public struct VGRCardView: View {
         }
     }
 
-    private var image: Image {
-        if imageUrl.isEmpty || imageUrl == "placeholder" {
+    /// The image to display, or `nil` when no `imageUrl` was provided.
+    private var image: Image? {
+        if imageUrl.isEmpty {
+            return nil
+        }
+
+        if imageUrl == "placeholder" {
             return Image("placeholder", bundle: .module)
         }
 
@@ -96,8 +101,8 @@ public struct VGRCardView: View {
             .font(.footnoteSemibold)
             .foregroundStyle(Color.Neutral.text)
             .dynamicTypeSize(.small ... .large)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 4)
+            .padding(.horizontal, .Margins.xtraSmall)
+            .padding(.vertical, .Margins.xtraSmall / 2)
             .background(Color.Primary.blueSurface)
             .cornerRadius(5)
     }
@@ -119,13 +124,15 @@ public struct VGRCardView: View {
 
     private var smallCard: some View {
         HStack(alignment: .top, spacing: 0) {
-            image
-                .resizable()
-                .scaledToFill()
-                .frame(width: 118)
-                .frame(idealHeight: sizeClass.idealCardHeight,
-                       alignment: .center)
-                .clipped()
+            if let image {
+                image
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: 118)
+                    .frame(idealHeight: sizeClass.idealCardHeight,
+                           alignment: .center)
+                    .clipped()
+            }
 
             VStack(alignment: .center, spacing: VGRSpacing.verticalMedium) {
                 Text(title)
@@ -152,6 +159,7 @@ public struct VGRCardView: View {
                     .padding(.top, VGRSpacing.horizontal)
             }
         }
+        .frame(idealHeight: sizeClass.idealCardHeight)
         .background(Color.Elevation.elevation1)
         .clipped()
         .cornerRadius(16)
@@ -160,17 +168,19 @@ public struct VGRCardView: View {
     private var mediumCard: some View {
         VStack(alignment: .leading, spacing: 0) {
             ZStack(alignment: .topTrailing) {
-                image
-                    .resizable()
-                    .scaledToFill()
-                    .frame(maxHeight: sizeClass.maxImageHeight, alignment: .center)
-                    .contentShape(Rectangle())
-                    .clipped()
-                    .clipShape(
-                        .rect(
-                            bottomLeadingRadius: VGRRadius.vgrCorner,
+                if let image {
+                    image
+                        .resizable()
+                        .scaledToFill()
+                        .frame(maxHeight: sizeClass.maxImageHeight, alignment: .center)
+                        .contentShape(Rectangle())
+                        .clipped()
+                        .clipShape(
+                            .rect(
+                                bottomLeadingRadius: VGRRadius.vgrCorner,
+                            )
                         )
-                    )
+                }
 
                 if isNew {
                     newContentIcon
@@ -202,17 +212,19 @@ public struct VGRCardView: View {
     private var largeCard: some View {
         VStack(alignment: .leading, spacing: 0) {
             ZStack(alignment: .topTrailing) {
-                image
-                    .resizable()
-                    .scaledToFill()
-                    .frame(maxHeight: sizeClass.maxImageHeight, alignment: .center)
-                    .contentShape(Rectangle())
-                    .clipped()
-                    .clipShape(
-                        .rect(
-                            bottomLeadingRadius: VGRRadius.vgrCorner,
+                if let image {
+                    image
+                        .resizable()
+                        .scaledToFill()
+                        .frame(maxHeight: sizeClass.maxImageHeight, alignment: .center)
+                        .contentShape(Rectangle())
+                        .clipped()
+                        .clipShape(
+                            .rect(
+                                bottomLeadingRadius: VGRRadius.vgrCorner,
+                            )
                         )
-                    )
+                }
 
                 if isNew {
                     newContentIcon
@@ -237,7 +249,7 @@ public struct VGRCardView: View {
             .padding(.trailing, VGRSpacing.horizontal)
         }
         .background(Color.Elevation.elevation1)
-        .cornerRadius(16)
+        .cornerRadius(.Radius.mainRadius)
         .clipped()
     }
 }
@@ -274,6 +286,18 @@ public struct VGRCardView: View {
                     title: "Treatment Options",
                     imageUrl: "placeholder",
                     isNew: false
+                )
+
+                VGRCardView(
+                    sizeClass: .small,
+                    title: "Migrän hos barn och ungdomar",
+                    isNew: true
+                )
+
+                VGRCardView(
+                    sizeClass: .small,
+                    title: "Läkemedelsbehandling vid migrän hos barn och ungdomar",
+                    isNew: true
                 )
 
                 VGRCardView(

--- a/Sources/DesignSystem/Views/Cards/Card/VGRCardView.swift
+++ b/Sources/DesignSystem/Views/Cards/Card/VGRCardView.swift
@@ -249,7 +249,7 @@ public struct VGRCardView: View {
             .padding(.trailing, VGRSpacing.horizontal)
         }
         .background(Color.Elevation.elevation1)
-        .cornerRadius(.Radius.mainRadius)
+        .cornerRadius(16)
         .clipped()
     }
 }


### PR DESCRIPTION
`VGRCardView` required an `imageUrl` and always rendered an image, falling back to the bundled `placeholder` asset when the string was empty. Cards without artwork now render as text-only.

## Changes

- `image` is now `Image?` — an empty `imageUrl` returns `nil` and the image is omitted from the layout in all three size classes (`small`, `medium`, `large`).
- The "new" badge still renders when there is no image; the medium/large `ZStack` collapses to zero height when there is neither image nor badge.
- `VGRCardButton.imageUrl` defaults to `""` so callers can omit it.
- Replaced hardcoded values with design tokens (`.Margins.xtraSmall`, `.Radius.mainRadius`) and moved the small card's ideal height off the image and onto the card itself.
- Previews cover the imageless variants.

## Testing

Previews only — check the imageless small card's leading padding against its imaged siblings.