### PR TITLE
Add accessibilitystatement content type

### DIFF
--- a/Sources/DesignSystem/Views/Screens/Content/Models/VGRContentType.swift
+++ b/Sources/DesignSystem/Views/Screens/Content/Models/VGRContentType.swift
@@ -14,6 +14,9 @@ public enum VGRContentType: String, Decodable {
     /// Privacy policy, structurally same as `article` and `learn`
     case privacypolicy
 
+    /// Accessibility statement, structurally same as `article` and `learn`
+    case accessibilitystatement
+
     /// FAQ article. Contains one or more elements with both question and answer.
     case faq
 


### PR DESCRIPTION
Adds a new `accessibilitystatement` case to `VGRContentType`, structurally identical to `article`, `learn` and `privacypolicy`.

Purely additive — the enum has no exhaustive switches elsewhere, and unknown raw values still fall back to `.article` in the custom decoder.