### PR TITLE
Implement video selector link elements

### DIFF
--- a/Sources/DesignSystem/Views/Screens/Content/VGRContentScreen.swift
+++ b/Sources/DesignSystem/Views/Screens/Content/VGRContentScreen.swift
@@ -55,6 +55,10 @@ public struct VGRContentScreen: View {
     /// Optional callback when feedback is submitted (for threshold articles with feedback elements)
     var onFeedbackSubmitted: ((VGRFeedbackResult) -> Void)? = nil
 
+    /// Optional callback when a video is selected in a video selector element, passes the
+    /// `.video` element. When nil, the video selector presents the player itself.
+    var onVideoSelected: ((VGRVideo) -> Void)? = nil
+
     /// Optional callback when an action callout button is tapped, passes the actionId
     var onActionCallout: ((String) -> Void)? = nil
 
@@ -64,16 +68,20 @@ public struct VGRContentScreen: View {
     ///   - dismissAction: Optional closure to execute when the screen is dismissed
     ///   - onFeedbackSubmitted: Optional callback when feedback is submitted
     ///   - onActionCallout: Optional callback when an action callout button is tapped
+    ///   - onVideoSelected: Optional callback when a video is selected in a video selector
+    ///     element. Pass nil to let the selector present the player itself.
     public init(
         content: VGRContent,
         dismissAction: (() -> Void)? = nil,
         onFeedbackSubmitted: ((VGRFeedbackResult) -> Void)? = nil,
-        onActionCallout: ((String) -> Void)? = nil
+        onActionCallout: ((String) -> Void)? = nil,
+        onVideoSelected: ((VGRVideo) -> Void)? = nil
     ) {
         self.content = content
         self.dismissAction = dismissAction
         self.onFeedbackSubmitted = onFeedbackSubmitted
         self.onActionCallout = onActionCallout
+        self.onVideoSelected = onVideoSelected
     }
 
     /// Focus state for managing keyboard navigation within the scroll view
@@ -99,7 +107,8 @@ public struct VGRContentScreen: View {
                         articleId: content.id,
                         dismissAction: dismissAction,
                         onFeedbackSubmitted: onFeedbackSubmitted,
-                        onActionCallout: onActionCallout
+                        onActionCallout: onActionCallout,
+                        onVideoSelected: onVideoSelected
                     )
                 }
             }

--- a/Sources/DesignSystem/Views/Screens/Content/Video/VGRVideo.swift
+++ b/Sources/DesignSystem/Views/Screens/Content/Video/VGRVideo.swift
@@ -18,3 +18,21 @@ public struct VGRVideo: Identifiable, VGRVideoCarouselItem {
    public let url: String
    public var publishDate: Date?
 }
+
+extension VGRVideo {
+
+    /// Creates a video from a `VGRContentElement` of type `.video`.
+    ///
+    /// A `.video` element carries exactly the fields a `VGRVideo` needs, so the two are
+    /// interchangeable representations of the same video.
+    public init(_ element: VGRContentElement) {
+        self.init(
+            id: element.videoId,
+            title: element.title,
+            subtitle: element.subtitle,
+            duration: element.readTime,
+            url: element.videoUrl,
+            publishDate: element.publishDate
+        )
+    }
+}

--- a/Sources/DesignSystem/Views/Screens/Content/Views/ContentElements/VGRContentVideoSelectorView.swift
+++ b/Sources/DesignSystem/Views/Screens/Content/Views/ContentElements/VGRContentVideoSelectorView.swift
@@ -1,0 +1,139 @@
+import SwiftUI
+
+/// A view that displays the videos of a video feed as a horizontal carousel.
+///
+/// Every `.video` element in the content becomes a card in the carousel, and the content's
+/// `title` and `subtitle` become the carousel header.
+///
+/// Reachable two ways. Inside a ``VGRContentScreen`` it renders a `.internalVideoSelectorLink`
+/// element, which points at the video feed through its `internalId` — that reference must already
+/// be resolved into `internalArticle` by the time the element is rendered. It can also be placed
+/// on its own screen by passing the video feed content directly.
+///
+/// Selection is handed to `onVideoSelected` when the consuming app supplies one, so the app can
+/// present its own player and record analytics. Without a callback the view plays the video itself,
+/// matching ``VGRContentVideoView``.
+public struct VGRContentVideoSelectorView: View {
+
+    /// The video feed whose `.video` elements fill the carousel.
+    public let content: VGRContent?
+
+    /// Called with the selected video. When nil, playback is handled by this view.
+    public var onVideoSelected: ((VGRVideo) -> Void)?
+
+    private var videoStatusService = VGRVideoStatusService.shared
+
+    /// Creates a video selector for a `.internalVideoSelectorLink` element.
+    /// - Parameters:
+    ///   - element: The element whose `internalArticle` holds the videos. Renders nothing if that
+    ///     reference has not been resolved.
+    ///   - onVideoSelected: Called with the tapped video. Pass nil to let this view present
+    ///     the player.
+    public init(element: VGRContentElement,
+                onVideoSelected: ((VGRVideo) -> Void)? = nil) {
+        self.content = element.internalArticle
+        self.onVideoSelected = onVideoSelected
+    }
+
+    /// Creates a video selector directly from video feed content, for use outside a
+    /// ``VGRContentScreen``.
+    /// - Parameters:
+    ///   - content: The video feed, conventionally of type `.videofeed`.
+    ///   - onVideoSelected: Called with the tapped video. Pass nil to let this view present
+    ///     the player.
+    public init(content: VGRContent,
+                onVideoSelected: ((VGRVideo) -> Void)? = nil) {
+        self.content = content
+        self.onVideoSelected = onVideoSelected
+    }
+
+    @State private var playingVideo: VGRVideo?
+
+    @ScaledMetric(relativeTo: .title3) private var carouselMinHeight: CGFloat = 330
+
+    /// The `.video` elements of the content, in authoring order.
+    private var videos: [VGRContentElement] {
+        content?.elements.filter { $0.type == .video } ?? []
+    }
+
+    private var items: [VGRVideo] {
+        videos.map(VGRVideo.init)
+    }
+
+    private func select(_ item: any VGRVideoCarouselItem) {
+        guard let video = items.first(where: { $0.id == item.id }) else { return }
+
+        if let onVideoSelected {
+            onVideoSelected(video)
+        } else {
+            playingVideo = video
+        }
+    }
+
+    public var body: some View {
+        if let content, !videos.isEmpty {
+            VGRVideoCarousel(
+                title: content.title,
+                subtitle: content.subtitle,
+                items: items,
+                onItemTapped: select
+            )
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .frame(minHeight: carouselMinHeight)
+            .padding(.vertical, VGRSpacing.verticalXLarge)
+            .fullScreenCover(item: $playingVideo) { video in
+                if let url = URL(string: video.url) {
+                    VGRVideoPlayer(
+                        url: url,
+                        onWatchedThresholdReached: {
+                            videoStatusService.markAsWatched(videoId: video.id)
+                        },
+                        onDismiss: {
+                            playingVideo = nil
+                        }
+                    )
+                    .ignoresSafeArea()
+                }
+            }
+        }
+    }
+}
+
+#Preview("Video selector") {
+    let videos = (1...4).map { index in
+        VGRContentElement(
+            type: .video,
+            title: "Del \(index):",
+            subtitle: "Vad är psoriasis?",
+            readTime: "\(index + 2) minuter",
+            videoUrl: "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4",
+            videoId: "sample-video-\(index)"
+        )
+    }
+
+    let feed = VGRContent(
+        title: "Videoklipp",
+        subtitle: "Korta filmer om psoriasis",
+        type: .videofeed,
+        imageUrl: "",
+        elements: videos
+    )
+
+    let element = VGRContentElement(
+        type: .internalVideoSelectorLink,
+        internalArticle: feed
+    )
+
+    return NavigationStack {
+        ScrollView {
+            /// From content, as placed on a screen of its own
+            VGRContentVideoSelectorView(content: feed)
+
+            /// From an element, as rendered inside a `VGRContentScreen`
+            VGRContentVideoSelectorView(element: element)
+        }
+        .background(Color.Elevation.background)
+        .navigationTitle("VGRContentVideoSelectorView")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/Sources/DesignSystem/Views/Screens/Content/Views/VGRContentElementView.swift
+++ b/Sources/DesignSystem/Views/Screens/Content/Views/VGRContentElementView.swift
@@ -93,6 +93,31 @@ struct VGRContentElementView: View {
 #Preview("All Element Types") {
     let linkedArticle = VGRContent.random()
 
+    let videoFeed = VGRContent(
+        title: "Videoklipp",
+        subtitle: "Korta filmer om psoriasis",
+        type: .videofeed,
+        imageUrl: "",
+        elements: [
+            VGRContentElement(
+                type: .video,
+                title: "Del 1:",
+                subtitle: "Vad är psoriasis?",
+                readTime: "3 minuter",
+                videoUrl: "https://player.vgregion.se/mobilapp1/smil:mc1/Y93sDHAABx5AnnK6V8uyEJ_iWRmspME7rM5UHSTvWcxFr/master.smil/playlist.m3u8",
+                videoId: "preview-selector-video-1"
+            ),
+            VGRContentElement(
+                type: .video,
+                title: "Del 2:",
+                subtitle: "Behandling och egenvård",
+                readTime: "5 minuter",
+                videoUrl: "https://player.vgregion.se/mobilapp1/smil:mc1/Hx5WiFEdNRwBinJhiUcqBn_bihwAfXDtaczHmBzJFgD46/master.smil/playlist.m3u8",
+                videoId: "preview-selector-video-2"
+            )
+        ]
+    )
+
     NavigationStack {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
@@ -244,6 +269,30 @@ struct VGRContentElementView: View {
                         readTime: "5 minuter",
                         videoUrl: "https://player.vgregion.se/mobilapp1/smil:mc1/Hx5WiFEdNRwBinJhiUcqBn_bihwAfXDtaczHmBzJFgD46/master.smil/playlist.m3u8",
                         videoId: "preview-video-2"
+                    )
+                )
+
+                // Video selector link, pointing at an already resolved video feed
+                VGRContentElementView(
+                    element: VGRContentElement(
+                        type: .internalVideoSelectorLink,
+                        internalArticle: videoFeed
+                    )
+                )
+
+                // H2 Title
+                VGRContentElementView(
+                    element: VGRContentElement(
+                        type: .h2,
+                        text: "Secondary Section Title",
+                    )
+                )
+
+                // More body text
+                VGRContentElementView(
+                    element: VGRContentElement(
+                        type: .body,
+                        text: "Another paragraph of body text to show how content flows between different sections.",
                     )
                 )
             }

--- a/Sources/DesignSystem/Views/Screens/Content/Views/VGRContentElementView.swift
+++ b/Sources/DesignSystem/Views/Screens/Content/Views/VGRContentElementView.swift
@@ -15,6 +15,9 @@ struct VGRContentElementView: View {
     /// Callback when an action callout button is tapped, passes the actionId
     var onActionCallout: ((String) -> Void)? = nil
 
+    /// Callback when a video is selected in a video selector element, passes the selected video
+    var onVideoSelected: ((VGRVideo) -> Void)? = nil
+
     var body: some View {
         Group {
             switch element.type {
@@ -46,8 +49,10 @@ struct VGRContentElementView: View {
                     VGRContentVideoView(element: element)
 
                 case .internalVideoSelectorLink:
-                    /// TODO Implement support for video selector link elements
-                    EmptyView()
+                    VGRContentVideoSelectorView(
+                        element: element,
+                        onVideoSelected: onVideoSelected
+                    )
 
                 case .faq:
                     EmptyView()


### PR DESCRIPTION
Implements `.internalVideoSelectorLink` elements, which previously rendered as an `EmptyView` placeholder.

### `VGRContentVideoSelectorView`
Renders the `.video` elements of a video feed as a horizontal `VGRVideoCarousel`, with the feed's `title`/`subtitle` as the carousel header. Two initialisers:

- `init(element:onVideoSelected:)` — for `.internalVideoSelectorLink` elements inside a `VGRContentScreen`. The element's `internalId` reference must already be resolved into `internalArticle`; the view renders nothing if it isn't.
- `init(content:onVideoSelected:)` — for placing the selector on a screen of its own.

### `onVideoSelected` on `VGRContentScreen`
New optional callback so consuming apps can present their own player and record analytics. When nil, the selector presents `VGRVideoPlayer` itself and marks the video watched via `VGRVideoStatusService`, matching `VGRContentVideoView`. The parameter is added last in the initialiser and defaults to nil, so existing call sites are unaffected.

### `VGRVideo.init(_ element:)`
A `.video` element carries exactly the fields a `VGRVideo` needs, so this makes the conversion explicit rather than repeating the field mapping at each use.