### PR TITLE
feature/add-voiceover-vgrsection

### DIFF
--- a/Sources/DesignSystem/Views/Lists/VGRSection.swift
+++ b/Sources/DesignSystem/Views/Lists/VGRSection.swift
@@ -125,6 +125,7 @@ public struct VGRSection<Header: View, Footer: View, Content: View>: View {
                         .multilineTextAlignment(.leading)
                         .foregroundStyle(Color.Neutral.text)
                         .padding(.horizontal, .Margins.medium)
+                        .accessibilityAddTraits(.isHeader)
                 }
                 .padding(.horizontal, inset ? .Margins.medium : 0)
             } else {

--- a/Sources/DesignSystem/Views/Lists/VGRSectionTitle.swift
+++ b/Sources/DesignSystem/Views/Lists/VGRSectionTitle.swift
@@ -94,6 +94,7 @@ public struct VGRSectionTitle<Accessory: View>: View {
             VStack(alignment: .leading, spacing: variant.spacing) {
                 Text(title)
                     .font(variant.titleFont)
+                    .accessibilityAddTraits(.isHeader)
 
                 if !description.isEmpty {
                     Text(description)


### PR DESCRIPTION
## Beskrivning
Lägg till .isHeader-trait på VGRSection/VGRSectionTitle.
VoiceOver läste VGRSection-rubriker som vanlig text i stället för rubriker — de saknades i rotorns "Headings"-navigering.

## Ändring
- VGRSection: .accessibilityAddTraits(.isHeader) på string-header-varianten
- VGRSectionTitle: samma trait på titel-texten