### PR TITLE
Add the missing navigation titles for content types

### DIFF
--- a/Sources/DesignSystem/Assets/sv.lproj/Localizable.strings
+++ b/Sources/DesignSystem/Assets/sv.lproj/Localizable.strings
@@ -153,7 +153,11 @@
 "content.type.tips.title" = "Tips";
 "content.type.useragreement.title" = "Användarpolicy";
 "content.type.privacypolicy.title" = "Personuppgiftspolicy";
+"content.type.accessibilitystatement.title" = "Tillgänglighetsredogörelse";
 "content.type.threshold.title" = "Meddelande";
+"content.type.faq.title" = "Frågor och svar";
+"content.type.videofeed.title" = "Videoklipp";
+"content.type.warning.title" = "Meddelande";
 
 "content.button.showmore" = "Visa fler";
 


### PR DESCRIPTION
## Summary

`VGRContentScreen` derives its navigation title from the content type:

```swift
content.type == .article ? content.title : "content.type.\(content.type).title".localizedBundle
```

Four of the nine `VGRContentType` cases had no such key in `Localizable.strings`. `NSLocalizedString` returns the key when a lookup misses, so those screens showed the literal string `content.type.faq.title` in the navigation bar instead of a title.

## Added

| Key | Value |
| --- | --- |
| `content.type.accessibilitystatement.title` | Tillgänglighetsredogörelse |
| `content.type.faq.title` | Frågor och svar |
| `content.type.videofeed.title` | Videoklipp |
| `content.type.warning.title` | Meddelande |

`warning` and `videofeed` reuse the wording already in the file, from `content.type.warning` and `content.type.video`. The `accessibilitystatement` case came in with #179; the other three predate it.

## Worth a second opinion

`faq` has no existing wording anywhere in the package, so "Frågor och svar" is a guess — if the apps already title that screen differently, this should match them.

## Testing

String catalogue only, no code changed. Every `VGRContentType` case now resolves to a key that exists.