### PR TITLE
Add markdown support in WhatsNew items

### DIFF
--- a/Sources/DesignSystem/Views/Screens/WhatsNew/Models/VGRWhatsNewChange.swift
+++ b/Sources/DesignSystem/Views/Screens/WhatsNew/Models/VGRWhatsNewChange.swift
@@ -68,6 +68,11 @@ public struct VGRWhatsNewChangeElement: Decodable, Identifiable, Hashable {
     /// Text content (used by body, subhead, h1 types)
     public let text: String
 
+    /// Convenience property
+    public var attributedText: AttributedString {
+        (try? AttributedString(markdown: text)) ?? AttributedString(text)
+    }
+
     /// Image asset name (used by image type)
     public let url: String
 

--- a/Sources/DesignSystem/Views/Screens/WhatsNew/VGRWhatsNewScreen.swift
+++ b/Sources/DesignSystem/Views/Screens/WhatsNew/VGRWhatsNewScreen.swift
@@ -119,7 +119,7 @@ public struct VGRWhatsNewScreen: View {
                     } label: {
                         HStack(spacing: 4) {
                             Image(systemName: "chevron.left")
-                                .padding(.leading, 8)
+                                .padding(.leading, .Margins.xtraSmall)
                             Text("whatsnew.back".localizedBundle)
                             Spacer()
                         }
@@ -138,7 +138,7 @@ public struct VGRWhatsNewScreen: View {
                     } label: {
                         Spacer()
                         Text("whatsnew.skip".localizedBundle)
-                            .padding(.trailing, 8)
+                            .padding(.trailing, .Margins.xtraSmall)
                     }
                     .frame(maxWidth: .infinity)
                     .accessibilityIdentifier("SkipButton")
@@ -175,7 +175,7 @@ public struct VGRWhatsNewScreen: View {
                     } label: {
                         Text(nextButtonTitle)
                             .foregroundColor(Color.Neutral.textInverted)
-                            .padding(.vertical, 12)
+                            .padding(.vertical, .Margins.small)
                             .frame(maxWidth: .infinity)
                     }
                     .buttonStyle(.borderedProminent)
@@ -185,7 +185,7 @@ public struct VGRWhatsNewScreen: View {
                     .accessibilityIdentifier("NextButton")
 
                 }
-                .padding(16)
+                .padding(.Margins.medium)
                 .background(Color.Elevation.background)
             }
 
@@ -294,7 +294,7 @@ public struct VGRWhatsNewScreen: View {
                     {
                         "order": 3,
                         "type": "body",
-                        "text": "Genom att titta på de nya filmerna kan du lära dig ännu mer om migrän."
+                        "text": "Genom att titta på **de nya filmerna** kan du lära dig ännu mer om migrän."
                     }
                 ]
             }

--- a/Sources/DesignSystem/Views/Screens/WhatsNew/Views/VGRWhatsNewItemView.swift
+++ b/Sources/DesignSystem/Views/Screens/WhatsNew/Views/VGRWhatsNewItemView.swift
@@ -15,21 +15,21 @@ public struct VGRWhatsNewItemView: View {
                     let element = change.elements[index]
                     switch element.type {
                         case .h1:
-                            Text(element.text)
+                            Text(element.attributedText)
                                 .font(.title).bold()
                                 .foregroundStyle(Color.Neutral.text)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .accessibilityAddTraits(.isHeader)
-                                .padding(.bottom, 12)
+                                .padding(.bottom, .Margins.small)
                                 .accessibilityRespondsToUserInteraction()
 
                         case .subhead:
-                            Text(element.text)
+                            Text(element.attributedText)
                                 .font(.headline).bold()
                                 .lineSpacing(6)
                                 .foregroundStyle(Color.Neutral.text)
                                 .frame(maxWidth: .infinity, alignment: .leading)
-                                .padding(.bottom, 32)
+                                .padding(.bottom, .Margins.xtraLarge)
                                 .accessibilityAddTraits(.isStaticText)
 
                         case .image:
@@ -45,7 +45,7 @@ public struct VGRWhatsNewItemView: View {
                             }
 
                         case .panel:
-                            VStack(spacing: 32) {
+                            VStack(spacing: .Margins.xtraLarge) {
                                 ForEach(element.elements.indices, id: \.self) { subElementIndex in
                                     let subElement = element.elements[subElementIndex]
                                     switch subElement.type {
@@ -62,7 +62,7 @@ public struct VGRWhatsNewItemView: View {
                                                     .accessibilityHidden(true)
                                             }
                                         default:
-                                            Text(subElement.text)
+                                            Text(subElement.attributedText)
                                                 .font(.body)
                                                 .lineSpacing(6)
                                                 .foregroundStyle(Color.Neutral.text)
@@ -74,21 +74,21 @@ public struct VGRWhatsNewItemView: View {
                             .padding(element.paddingValue)
                             .background(Color.Elevation.elevation1)
                             .clipShape(RoundedRectangle(cornerRadius: 8))
-                            .padding(.bottom, 16)
+                            .padding(.bottom, .Margins.medium)
 
                         default:
-                            Text(element.text)
+                            Text(element.attributedText)
                                 .font(.body)
                                 .lineSpacing(6)
                                 .foregroundStyle(Color.Neutral.text)
                                 .frame(maxWidth: .infinity, alignment: .leading)
-                                .padding(.bottom, 32)
+                                .padding(.bottom, .Margins.xtraLarge)
                                 .accessibilityAddTraits(.isStaticText)
                     }
                 }
 
             }
-            .padding(16)
+            .padding(.Margins.medium)
             .frame(maxWidth: .infinity)
             .accessibilityElement(children: .contain)
             .accessibilityTextContentType(.narrative)
@@ -105,17 +105,17 @@ public struct VGRWhatsNewItemView: View {
         {
             "order": 1,
             "type": "h1",
-            "text": "Saknas läkemedlet?"
+            "text": "_Saknas_ läkemedlet?"
         },
         {
             "order": 2,
             "type": "subhead",
-            "text": "Saknas ditt läkemedel i listan över vanliga läkemedel?"
+            "text": "Saknas ditt _läkemedel_ i listan över vanliga läkemedel?"
         },
         {
             "order": 3,
             "type": "body",
-            "text": "Nu kan du ange namn på läkemedel som du själv lägger till. Du kan också ändra namn på läkemedel som du lagt till tidigare."
+            "text": "Nu kan du **ange namn** på läkemedel som du själv lägger till. Du kan också **ändra namn** på läkemedel som du lagt till tidigare."
         }
     ]
     """


### PR DESCRIPTION
## Summary
- Render `h1`, `subhead`, `body` and panel texts in WhatsNew items as `AttributedString` parsed from markdown (falls back to plain text if parsing fails)
- Replace hardcoded padding values with `.Margins` tokens in `VGRWhatsNewScreen` and `VGRWhatsNewItemView`
- Update previews with markdown samples (bold/italic)