### PR TITLE
Fix Recurrence.getRecurringDates always spinning 10,000 iterations

### DIFF
--- a/Sources/DesignSystem/Views/Pickers/RecurrencePicker/Recurrence.swift
+++ b/Sources/DesignSystem/Views/Pickers/RecurrencePicker/Recurrence.swift
@@ -115,6 +115,14 @@ public struct Recurrence: Codable, Equatable, Hashable, Sendable {
     public func getRecurringDates(for dateInterval: DateInterval,
                                   filter: DateInterval? = nil,
                                   deviations: [RecurrenceDeviation] = []) -> [Date] {
+        calculateRecurringDates(for: dateInterval, filter: filter, deviations: deviations).dates
+    }
+
+    /// Internal worker that also reports the number of loop iterations,
+    /// so tests can verify the loop terminates as soon as the interval is exceeded.
+    internal func calculateRecurringDates(for dateInterval: DateInterval,
+                                          filter: DateInterval? = nil,
+                                          deviations: [RecurrenceDeviation] = []) -> (dates: [Date], iterations: Int) {
         let calendar = Calendar.current
         let interval = DateInterval(start: dateInterval.start.startOfDay, end: dateInterval.end.endOfDay)
         var currentDate = interval.start
@@ -131,33 +139,37 @@ public struct Recurrence: Codable, Equatable, Hashable, Sendable {
         }
 
         var failSafe: Int = 10000
+        var iterations: Int = 0
 
-        while true {
+        // The loop label is load-bearing: an unlabeled `break` inside the switch
+        // only exits the switch, leaving the loop to spin until failSafe runs out.
+        loop: while true {
             if failSafe <= 0 { break }
             failSafe -= 1
+            iterations += 1
 
             switch self.period {
                 case .day:
                     // Every X:th day
                     // Check if currentDate is beyond the interval before processing
                     if calendar.compare(currentDate, to: interval.end, toGranularity: .day) == .orderedDescending {
-                        break
+                        break loop
                     }
 
                     addDate(currentDate)
 
-                    guard let nextDate = calendar.date(byAdding: .day, value: self.frequency, to: currentDate) else { break }
+                    guard let nextDate = calendar.date(byAdding: .day, value: self.frequency, to: currentDate) else { break loop }
                     currentDate = nextDate
 
                 case .week:
                     // Every X:th week on [Y] days
-                    guard let weekdays = self.weekdays else { break }
+                    guard let weekdays = self.weekdays else { break loop }
 
                     let currentWeek = DateInterval(start: currentDate.startOfWeek.startOfDay, end: currentDate.endOfWeek.endOfDay)
 
                     // Check if the start of the current week is beyond the interval
                     if calendar.compare(currentWeek.start, to: interval.end, toGranularity: .day) == .orderedDescending {
-                        break
+                        break loop
                     }
 
                     let weekdayInts = weekdays.map { Int($0.rawValue) }
@@ -166,7 +178,7 @@ public struct Recurrence: Codable, Equatable, Hashable, Sendable {
 
                     guard let nextDate = calendar.date(byAdding: .weekOfYear,
                                                        value: self.frequency,
-                                                       to: currentDate) else { break }
+                                                       to: currentDate) else { break loop }
                     currentDate = nextDate
 
                 case .month:
@@ -176,16 +188,16 @@ public struct Recurrence: Codable, Equatable, Hashable, Sendable {
                         dayIndex = dateInterval.start.dayInMonth
                     }
 
-                    guard let date = calendar.dateWithSpecificDay(from: currentDate, dayIndex: dayIndex) else { break }
+                    guard let date = calendar.dateWithSpecificDay(from: currentDate, dayIndex: dayIndex) else { break loop }
 
                     // Check if the calculated date is beyond the interval before adding
                     if calendar.compare(date, to: interval.end, toGranularity: .day) == .orderedDescending {
-                        break
+                        break loop
                     }
 
                     addDate(date)
 
-                    guard let nextDate = calendar.date(byAdding: .month, value: self.frequency, to: currentDate) else { break }
+                    guard let nextDate = calendar.date(byAdding: .month, value: self.frequency, to: currentDate) else { break loop }
                     currentDate = nextDate
             }
         }
@@ -207,7 +219,7 @@ public struct Recurrence: Codable, Equatable, Hashable, Sendable {
             }
         }
 
-        return dates
+        return (dates, iterations)
     }
 }
 

--- a/Tests/designsystem-Tests/RecurrenceTests.swift
+++ b/Tests/designsystem-Tests/RecurrenceTests.swift
@@ -215,6 +215,52 @@ final class RecurrenceTests: XCTestCase {
         XCTAssertGreaterThan(dates.count, 79, "Should return more than 79 dates (bug returned exactly 79)")
     }
 
+    // MARK: - Loop Termination Tests
+
+    /// The `while true` loop used unlabeled `break`s inside its switch, which only
+    /// exited the switch — so every call spun through all 10 000 failSafe iterations.
+    /// These tests assert the loop stops as soon as the interval is exceeded.
+
+    func testDailyRecurrenceTerminatesEarly() throws {
+        let recurrence = Recurrence(frequency: 1, period: .day)
+        let interval = DateInterval(start: createDate("2025-01-01"), end: createDate("2025-01-05"))
+
+        let result = recurrence.calculateRecurringDates(for: interval)
+
+        XCTAssertEqual(result.dates.count, 5)
+        XCTAssertLessThanOrEqual(result.iterations, 6, "Loop should stop right after passing the interval end")
+    }
+
+    func testWeeklyRecurrenceTerminatesEarly() throws {
+        let recurrence = Recurrence(frequency: 1, period: .week, weekdays: [.monday])
+        let interval = DateInterval(start: createDate("2025-01-01"), end: createDate("2025-01-31"))
+
+        let result = recurrence.calculateRecurringDates(for: interval)
+
+        XCTAssertEqual(result.dates.count, 4)
+        XCTAssertLessThanOrEqual(result.iterations, 7, "Loop should stop right after passing the interval end")
+    }
+
+    func testWeeklyRecurrenceWithoutWeekdaysTerminatesImmediately() throws {
+        let recurrence = Recurrence(frequency: 1, period: .week, weekdays: nil)
+        let interval = DateInterval(start: createDate("2025-01-01"), end: createDate("2025-01-31"))
+
+        let result = recurrence.calculateRecurringDates(for: interval)
+
+        XCTAssertEqual(result.dates.count, 0)
+        XCTAssertEqual(result.iterations, 1, "Loop should exit on the first iteration when weekdays is nil")
+    }
+
+    func testMonthlyRecurrenceTerminatesEarly() throws {
+        let recurrence = Recurrence(frequency: 1, period: .month, index: 15)
+        let interval = DateInterval(start: createDate("2025-01-01"), end: createDate("2025-12-31"))
+
+        let result = recurrence.calculateRecurringDates(for: interval)
+
+        XCTAssertEqual(result.dates.count, 12)
+        XCTAssertLessThanOrEqual(result.iterations, 13, "Loop should stop right after passing the interval end")
+    }
+
     // MARK: - Monthly Recurrence Tests
 
     func testMonthlyRecurrenceEveryMonth() throws {


### PR DESCRIPTION
## Summary

`Recurrence.getRecurringDates` uses a `while true` loop with a `switch` inside it. All of the loop's termination `break`s (the interval-exceeded checks and the `guard ... else { break }` statements) sat inside switch cases — and in Swift an unlabeled `break` inside a `switch` exits the switch, not the enclosing loop. The only real exit was the `failSafe` counter, so **every call ran exactly 10,000 iterations of Calendar work** regardless of interval size. Results were still correct (dates are guarded by `interval.contains`), making this a pure performance bug affecting every consuming app.

## Changes

- Label the loop (`loop: while true`) and use `break loop` for all termination paths, so the loop exits as soon as the interval is exceeded.
- `getRecurringDates` now delegates to an internal `calculateRecurringDates` that also reports the iteration count, so tests can assert early termination.
- Added regression tests asserting iteration counts for daily/weekly/monthly recurrences (previously each of these ran 10,000 iterations; now e.g. a 5-day daily interval runs 6).

## Testing

Existing `RecurrenceTests` cover correctness of the returned dates (unchanged behavior); new loop-termination tests cover the perf regression. Tests not run locally — please verify in Xcode before merging.